### PR TITLE
[CXP-220] Add work location name and address to user profiles

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -1,45 +1,45 @@
 {
-  "@type":  "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
-  "resourceTypeCapabilities":  [
+  "@type": "type.googleapis.com/c1.connector.v2.ConnectorCapabilities",
+  "resourceTypeCapabilities": [
     {
-      "resourceType":  {
-        "id":  "team",
-        "displayName":  "Team",
-        "traits":  [
+      "resourceType": {
+        "id": "team",
+        "displayName": "Team",
+        "traits": [
           "TRAIT_GROUP"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.SkipGrants"
+            "@type": "type.googleapis.com/c1.connector.v2.SkipGrants"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC"
       ],
-      "permissions":  {}
+      "permissions": {}
     },
     {
-      "resourceType":  {
-        "id":  "user",
-        "displayName":  "User",
-        "traits":  [
+      "resourceType": {
+        "id": "user",
+        "displayName": "User",
+        "traits": [
           "TRAIT_USER"
         ],
-        "annotations":  [
+        "annotations": [
           {
-            "@type":  "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
           }
         ]
       },
-      "capabilities":  [
+      "capabilities": [
         "CAPABILITY_SYNC"
       ],
-      "permissions":  {}
+      "permissions": {}
     }
   ],
-  "connectorCapabilities":  [
+  "connectorCapabilities": [
     "CAPABILITY_SYNC"
   ],
-  "credentialDetails":  {}
+  "credentialDetails": {}
 }

--- a/cmd/baton-rippling/main.go
+++ b/cmd/baton-rippling/main.go
@@ -57,7 +57,7 @@ func getConnector(ctx context.Context, config *cfg.Rippling, runTimeOpts cli.Run
 		Department:     config.ExpandDepartment,
 		EmploymentType: config.ExpandEmploymentType,
 		Level:          config.ExpandLevel,
-	})
+	}, config.ExpandWorkLocations)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/cmd/baton-rippling/main.go
+++ b/cmd/baton-rippling/main.go
@@ -53,7 +53,7 @@ func getConnector(ctx context.Context, config *cfg.Rippling, runTimeOpts cli.Run
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, config.ApiToken, client.ExpandOptions{
+	cb, err := connector.New(ctx, config.ApiToken, config.BaseUrl, client.ExpandOptions{
 		Department:     config.ExpandDepartment,
 		EmploymentType: config.ExpandEmploymentType,
 		Level:          config.ExpandLevel,

--- a/config_schema.json
+++ b/config_schema.json
@@ -121,6 +121,12 @@
       "displayName": "Expand level",
       "description": "Include level data in worker sync. Requires the levels.read scope.",
       "boolField": {}
+    },
+    {
+      "name": "expand-work-locations",
+      "displayName": "Expand work locations",
+      "description": "Include work location name and address in user profiles. Requires the work-locations.read scope.",
+      "boolField": {}
     }
   ],
   "displayName": "Rippling",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,9 @@ type Client struct {
 }
 
 func New(ctx context.Context, apiToken string, baseURL string, expandOpts ExpandOptions) (*Client, error) {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	client, err := uhttp.NewBearerAuth(apiToken).GetClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
@@ -39,10 +40,10 @@ func New(ctx context.Context, apiToken string, baseURL string, expandOpts Expand
 	}, nil
 }
 
-func (c *Client) usersURL() string         { return c.baseURL + usersPath }
-func (c *Client) teamsURL() string         { return c.baseURL + teamsPath }
-func (c *Client) workersURL() string       { return c.baseURL + workersPath }
-func (c *Client) workLocationsURL() string { return c.baseURL + workLocationsPath }
+func (c *Client) usersURL() string         { u, _ := url.JoinPath(c.baseURL, usersPath); return u }
+func (c *Client) teamsURL() string         { u, _ := url.JoinPath(c.baseURL, teamsPath); return u }
+func (c *Client) workersURL() string       { u, _ := url.JoinPath(c.baseURL, workersPath); return u }
+func (c *Client) workLocationsURL() string { u, _ := url.JoinPath(c.baseURL, workLocationsPath); return u }
 
 func (c *Client) buildExpandParam() string {
 	// Manager is always expanded since it only requires the workers.read scope

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,7 +29,7 @@ func New(ctx context.Context, apiToken string, baseURL string, expandOpts Expand
 
 	client, err := uhttp.NewBearerAuth(apiToken).GetClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		return nil, fmt.Errorf("baton-rippling: failed to create HTTP client: %w", err)
 	}
 
 	return &Client{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,10 +17,13 @@ type ExpandOptions struct {
 
 type Client struct {
 	*uhttp.BaseHttpClient
+	baseURL       string
 	expandOptions ExpandOptions
 }
 
-func New(ctx context.Context, apiToken string, expandOpts ExpandOptions) (*Client, error) {
+func New(ctx context.Context, apiToken string, baseURL string, expandOpts ExpandOptions) (*Client, error) {
+	baseURL = strings.TrimRight(baseURL, "/")
+
 	client, err := uhttp.NewBearerAuth(apiToken).GetClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
@@ -28,9 +31,15 @@ func New(ctx context.Context, apiToken string, expandOpts ExpandOptions) (*Clien
 
 	return &Client{
 		BaseHttpClient: uhttp.NewBaseHttpClient(client),
+		baseURL:        baseURL,
 		expandOptions:  expandOpts,
 	}, nil
 }
+
+func (c *Client) usersURL() string         { return c.baseURL + usersPath }
+func (c *Client) teamsURL() string         { return c.baseURL + teamsPath }
+func (c *Client) workersURL() string       { return c.baseURL + workersPath }
+func (c *Client) workLocationsURL() string { return c.baseURL + workLocationsPath }
 
 func (c *Client) buildExpandParam() string {
 	// Manager is always expanded since it only requires the workers.read scope

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
@@ -36,11 +37,6 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		logBody(ctx, res.Body)
-		return &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
 	return &ratelimitData, nil
 }
 
@@ -48,10 +44,13 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 	// Build the base URL with expand params so that doGet handles the rest.
 	// The expand param is only needed on the initial request; next_link URLs
 	// already include it.
-	baseURL := c.workersURL()
+	u, _ := url.Parse(c.workersURL())
 	if expand := c.buildExpandParam(); expand != "" {
-		baseURL += "?expand=" + expand
+		q := u.Query()
+		q.Set("expand", expand)
+		u.RawQuery = q.Encode()
 	}
+	baseURL := u.String()
 
 	var workers WorkersResponse
 	rl, err := c.doGet(ctx, baseURL, nextLink, &workers)

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -29,13 +29,11 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 	)
 	if err != nil {
 		if res != nil {
-			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
 		return &ratelimitData, fmt.Errorf("request to %s failed: %w", baseURL, err)
 	}
 
-	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		logBody(ctx, res.Body)
 		return &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -18,7 +18,7 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("baton-rippling: failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	var ratelimitData v2.RateLimitDescription
@@ -32,13 +32,13 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
-		return &ratelimitData, fmt.Errorf("baton-rippling: request to %s failed: %w", baseURL, err)
+		return &ratelimitData, fmt.Errorf("request to %s failed: %w", baseURL, err)
 	}
 
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		logBody(ctx, res.Body)
-		return &ratelimitData, fmt.Errorf("baton-rippling: unexpected status code: %d", res.StatusCode)
+		return &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
 	}
 
 	return &ratelimitData, nil
@@ -56,7 +56,7 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 	var workers WorkersResponse
 	rl, err := c.doGet(ctx, baseURL, nextLink, &workers)
 	if err != nil {
-		return nil, rl, fmt.Errorf("baton-rippling: failed to list workers: %w", err)
+		return nil, rl, fmt.Errorf("failed to list workers: %w", err)
 	}
 	return &workers, rl, nil
 }
@@ -65,7 +65,7 @@ func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse
 	var teams TeamsResponse
 	rl, err := c.doGet(ctx, c.teamsURL(), nextLink, &teams)
 	if err != nil {
-		return nil, rl, fmt.Errorf("baton-rippling: failed to list teams: %w", err)
+		return nil, rl, fmt.Errorf("failed to list teams: %w", err)
 	}
 	return &teams, rl, nil
 }
@@ -74,7 +74,7 @@ func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkL
 	var workLocations WorkLocationsResponse
 	rl, err := c.doGet(ctx, c.workLocationsURL(), nextLink, &workLocations)
 	if err != nil {
-		return nil, rl, fmt.Errorf("baton-rippling: failed to list work locations: %w", err)
+		return nil, rl, fmt.Errorf("failed to list work locations: %w", err)
 	}
 	return &workLocations, rl, nil
 }
@@ -83,7 +83,7 @@ func (c *Client) ListUsers(ctx context.Context, nextLink string) (*UsersResponse
 	var usersResponse UsersResponse
 	rl, err := c.doGet(ctx, c.usersURL(), nextLink, &usersResponse)
 	if err != nil {
-		return nil, rl, fmt.Errorf("baton-rippling: failed to list users: %w", err)
+		return nil, rl, fmt.Errorf("failed to list users: %w", err)
 	}
 	return &usersResponse, rl, nil
 }

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -29,10 +29,12 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 	)
 	if err != nil {
 		if res != nil {
+			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
 		return &ratelimitData, fmt.Errorf("request to %s failed: %w", baseURL, err)
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		logBody(ctx, res.Body)

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -9,6 +9,40 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
+// doGet performs a GET request to the given URL (or nextLink if non-empty),
+// deserializes the JSON response into target, and returns rate limit data.
+func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any) (*v2.RateLimitDescription, error) {
+	url := baseURL
+	if nextLink != "" {
+		url = nextLink
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var ratelimitData v2.RateLimitDescription
+	res, err := c.Do(
+		req,
+		uhttp.WithJSONResponse(target),
+		uhttp.WithRatelimitData(&ratelimitData),
+	)
+	if err != nil {
+		if res != nil {
+			logBody(ctx, res.Body)
+		}
+		return &ratelimitData, fmt.Errorf("request to %s failed: %w", baseURL, err)
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		logBody(ctx, res.Body)
+		return &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	return &ratelimitData, nil
+}
+
 func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResponse, *v2.RateLimitDescription, error) {
 	url := WorkersURL
 	if nextLink != "" {
@@ -52,100 +86,28 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 }
 
 func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse, *v2.RateLimitDescription, error) {
-	url := TeamsURL
-	if nextLink != "" {
-		url = nextLink
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	var ratelimitData v2.RateLimitDescription
 	var teams TeamsResponse
-	res, err := c.Do(
-		req,
-		uhttp.WithJSONResponse(&teams),
-		uhttp.WithRatelimitData(&ratelimitData),
-	)
+	rl, err := c.doGet(ctx, TeamsURL, nextLink, &teams)
 	if err != nil {
-		if res != nil {
-			logBody(ctx, res.Body)
-		}
-		return nil, &ratelimitData, fmt.Errorf("failed to list teams: %w", err)
+		return nil, rl, fmt.Errorf("failed to list teams: %w", err)
 	}
-
-	defer res.Body.Close()
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		logBody(ctx, res.Body)
-		return nil, &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
-	return &teams, &ratelimitData, nil
+	return &teams, rl, nil
 }
 
 func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkLocationsResponse, *v2.RateLimitDescription, error) {
-	url := WorkLocationsURL
-	if nextLink != "" {
-		url = nextLink
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	var ratelimitData v2.RateLimitDescription
 	var workLocations WorkLocationsResponse
-	res, err := c.Do(
-		req,
-		uhttp.WithJSONResponse(&workLocations),
-		uhttp.WithRatelimitData(&ratelimitData),
-	)
+	rl, err := c.doGet(ctx, WorkLocationsURL, nextLink, &workLocations)
 	if err != nil {
-		if res != nil {
-			logBody(ctx, res.Body)
-		}
-		return nil, &ratelimitData, fmt.Errorf("failed to list work locations: %w", err)
+		return nil, rl, fmt.Errorf("failed to list work locations: %w", err)
 	}
-
-	defer res.Body.Close()
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		logBody(ctx, res.Body)
-		return nil, &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
-	return &workLocations, &ratelimitData, nil
+	return &workLocations, rl, nil
 }
 
 func (c *Client) ListUsers(ctx context.Context, nextLink string) (*UsersResponse, *v2.RateLimitDescription, error) {
-	url := UsersURL
-	if nextLink != "" {
-		url = nextLink
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	var ratelimitData v2.RateLimitDescription
 	var usersResponse UsersResponse
-	res, err := c.Do(
-		req,
-		uhttp.WithJSONResponse(&usersResponse),
-		uhttp.WithRatelimitData(&ratelimitData),
-	)
+	rl, err := c.doGet(ctx, UsersURL, nextLink, &usersResponse)
 	if err != nil {
-		if res != nil {
-			logBody(ctx, res.Body)
-		}
-		return nil, &ratelimitData, fmt.Errorf("failed to list users: %w", err)
+		return nil, rl, fmt.Errorf("failed to list users: %w", err)
 	}
-
-	defer res.Body.Close()
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		logBody(ctx, res.Body)
-		return nil, &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
-	return &usersResponse, &ratelimitData, nil
+	return &usersResponse, rl, nil
 }

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -45,46 +45,20 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 }
 
 func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResponse, *v2.RateLimitDescription, error) {
-	url := c.workersURL()
-	if nextLink != "" {
-		url = nextLink
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("baton-rippling: failed to create request: %w", err)
-	}
-
-	// Only add expand params on the initial request; next_link URLs already include them.
-	if nextLink == "" {
-		if expand := c.buildExpandParam(); expand != "" {
-			q := req.URL.Query()
-			q.Set("expand", expand)
-			req.URL.RawQuery = q.Encode()
-		}
+	// Build the base URL with expand params so that doGet handles the rest.
+	// The expand param is only needed on the initial request; next_link URLs
+	// already include it.
+	baseURL := c.workersURL()
+	if expand := c.buildExpandParam(); expand != "" {
+		baseURL += "?expand=" + expand
 	}
 
-	var ratelimitData v2.RateLimitDescription
 	var workers WorkersResponse
-	res, err := c.Do(
-		req,
-		uhttp.WithJSONResponse(&workers),
-		uhttp.WithRatelimitData(&ratelimitData),
-	)
+	rl, err := c.doGet(ctx, baseURL, nextLink, &workers)
 	if err != nil {
-		if res != nil {
-			defer res.Body.Close()
-			logBody(ctx, res.Body)
-		}
-		return nil, &ratelimitData, fmt.Errorf("baton-rippling: failed to list workers: %w", err)
+		return nil, rl, fmt.Errorf("baton-rippling: failed to list workers: %w", err)
 	}
-
-	defer res.Body.Close()
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		logBody(ctx, res.Body)
-		return nil, &ratelimitData, fmt.Errorf("baton-rippling: unexpected status code: %d", res.StatusCode)
-	}
-
-	return &workers, &ratelimitData, nil
+	return &workers, rl, nil
 }
 
 func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse, *v2.RateLimitDescription, error) {

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -18,7 +18,7 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("baton-rippling: failed to create request: %w", err)
 	}
 
 	var ratelimitData v2.RateLimitDescription
@@ -32,13 +32,13 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
-		return &ratelimitData, fmt.Errorf("request to %s failed: %w", baseURL, err)
+		return &ratelimitData, fmt.Errorf("baton-rippling: request to %s failed: %w", baseURL, err)
 	}
 
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		logBody(ctx, res.Body)
-		return &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return &ratelimitData, fmt.Errorf("baton-rippling: unexpected status code: %d", res.StatusCode)
 	}
 
 	return &ratelimitData, nil
@@ -51,7 +51,7 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, nil, fmt.Errorf("baton-rippling: failed to create request: %w", err)
 	}
 
 	// Only add expand params on the initial request; next_link URLs already include them.
@@ -75,13 +75,13 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
-		return nil, &ratelimitData, fmt.Errorf("failed to list workers: %w", err)
+		return nil, &ratelimitData, fmt.Errorf("baton-rippling: failed to list workers: %w", err)
 	}
 
 	defer res.Body.Close()
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		logBody(ctx, res.Body)
-		return nil, &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return nil, &ratelimitData, fmt.Errorf("baton-rippling: unexpected status code: %d", res.StatusCode)
 	}
 
 	return &workers, &ratelimitData, nil
@@ -91,7 +91,7 @@ func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse
 	var teams TeamsResponse
 	rl, err := c.doGet(ctx, c.teamsURL(), nextLink, &teams)
 	if err != nil {
-		return nil, rl, fmt.Errorf("failed to list teams: %w", err)
+		return nil, rl, fmt.Errorf("baton-rippling: failed to list teams: %w", err)
 	}
 	return &teams, rl, nil
 }
@@ -100,7 +100,7 @@ func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkL
 	var workLocations WorkLocationsResponse
 	rl, err := c.doGet(ctx, c.workLocationsURL(), nextLink, &workLocations)
 	if err != nil {
-		return nil, rl, fmt.Errorf("failed to list work locations: %w", err)
+		return nil, rl, fmt.Errorf("baton-rippling: failed to list work locations: %w", err)
 	}
 	return &workLocations, rl, nil
 }
@@ -109,7 +109,7 @@ func (c *Client) ListUsers(ctx context.Context, nextLink string) (*UsersResponse
 	var usersResponse UsersResponse
 	rl, err := c.doGet(ctx, c.usersURL(), nextLink, &usersResponse)
 	if err != nil {
-		return nil, rl, fmt.Errorf("failed to list users: %w", err)
+		return nil, rl, fmt.Errorf("baton-rippling: failed to list users: %w", err)
 	}
 	return &usersResponse, rl, nil
 }

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -29,6 +29,7 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 	)
 	if err != nil {
 		if res != nil {
+			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
 		return &ratelimitData, fmt.Errorf("request to %s failed: %w", baseURL, err)
@@ -71,6 +72,7 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 	)
 	if err != nil {
 		if res != nil {
+			defer res.Body.Close()
 			logBody(ctx, res.Body)
 		}
 		return nil, &ratelimitData, fmt.Errorf("failed to list workers: %w", err)

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -44,7 +44,7 @@ func (c *Client) doGet(ctx context.Context, baseURL, nextLink string, target any
 }
 
 func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResponse, *v2.RateLimitDescription, error) {
-	url := WorkersURL
+	url := c.workersURL()
 	if nextLink != "" {
 		url = nextLink
 	}
@@ -87,7 +87,7 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 
 func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse, *v2.RateLimitDescription, error) {
 	var teams TeamsResponse
-	rl, err := c.doGet(ctx, TeamsURL, nextLink, &teams)
+	rl, err := c.doGet(ctx, c.teamsURL(), nextLink, &teams)
 	if err != nil {
 		return nil, rl, fmt.Errorf("failed to list teams: %w", err)
 	}
@@ -96,7 +96,7 @@ func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse
 
 func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkLocationsResponse, *v2.RateLimitDescription, error) {
 	var workLocations WorkLocationsResponse
-	rl, err := c.doGet(ctx, WorkLocationsURL, nextLink, &workLocations)
+	rl, err := c.doGet(ctx, c.workLocationsURL(), nextLink, &workLocations)
 	if err != nil {
 		return nil, rl, fmt.Errorf("failed to list work locations: %w", err)
 	}
@@ -105,7 +105,7 @@ func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkL
 
 func (c *Client) ListUsers(ctx context.Context, nextLink string) (*UsersResponse, *v2.RateLimitDescription, error) {
 	var usersResponse UsersResponse
-	rl, err := c.doGet(ctx, UsersURL, nextLink, &usersResponse)
+	rl, err := c.doGet(ctx, c.usersURL(), nextLink, &usersResponse)
 	if err != nil {
 		return nil, rl, fmt.Errorf("failed to list users: %w", err)
 	}

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -84,6 +84,39 @@ func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse
 	return &teams, &ratelimitData, nil
 }
 
+func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkLocationsResponse, *v2.RateLimitDescription, error) {
+	url := WorkLocationsURL
+	if nextLink != "" {
+		url = nextLink
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var ratelimitData v2.RateLimitDescription
+	var workLocations WorkLocationsResponse
+	res, err := c.Do(
+		req,
+		uhttp.WithJSONResponse(&workLocations),
+		uhttp.WithRatelimitData(&ratelimitData),
+	)
+	if err != nil {
+		if res != nil {
+			logBody(ctx, res.Body)
+		}
+		return nil, &ratelimitData, fmt.Errorf("failed to list work locations: %w", err)
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		logBody(ctx, res.Body)
+		return nil, &ratelimitData, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	return &workLocations, &ratelimitData, nil
+}
+
 func (c *Client) ListUsers(ctx context.Context, nextLink string) (*UsersResponse, *v2.RateLimitDescription, error) {
 	url := UsersURL
 	if nextLink != "" {

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -34,7 +34,6 @@ type Name struct {
 	FamilyName          string `json:"family_name,omitempty"`
 	PreferredGivenName  string `json:"preferred_given_name,omitempty"`
 	PreferredFamilyName string `json:"preferred_family_name,omitempty"`
-	DisplayName         string `json:"display_name"`
 }
 
 type User struct {
@@ -43,6 +42,7 @@ type User struct {
 	UpdatedAt         string        `json:"updated_at"`
 	Active            bool          `json:"active"`
 	Username          string        `json:"username"`
+	DisplayName       string        `json:"display_name"`
 	Name              Name          `json:"name"`
 	Emails            []Email       `json:"emails"`
 	PhoneNumbers      []PhoneNumber `json:"phone_numbers"`
@@ -90,6 +90,7 @@ type WorkerUser struct {
 	UpdatedAt         string        `json:"updated_at"`
 	Active            bool          `json:"active,omitempty"`
 	Username          string        `json:"username,omitempty"`
+	DisplayName       string        `json:"display_name,omitempty"`
 	Name              Name          `json:"name,omitempty"`
 	Emails            []Email       `json:"emails,omitempty"`
 	PhoneNumbers      []PhoneNumber `json:"phone_numbers,omitempty"`

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -28,7 +28,13 @@ type Photo struct {
 }
 
 type Name struct {
-	DisplayName string `json:"display_name"`
+	Formatted           string `json:"formatted,omitempty"`
+	GivenName           string `json:"given_name,omitempty"`
+	MiddleName          string `json:"middle_name,omitempty"`
+	FamilyName          string `json:"family_name,omitempty"`
+	PreferredGivenName  string `json:"preferred_given_name,omitempty"`
+	PreferredFamilyName string `json:"preferred_family_name,omitempty"`
+	DisplayName         string `json:"display_name"`
 }
 
 type User struct {
@@ -78,23 +84,13 @@ type TeamsResponse struct {
 	NextLink string `json:"next_link,omitempty"`
 }
 
-type WorkerName struct {
-	Formatted           string `json:"formatted,omitempty"`
-	GivenName           string `json:"given_name,omitempty"`
-	MiddleName          string `json:"middle_name,omitempty"`
-	FamilyName          string `json:"family_name,omitempty"`
-	PreferredGivenName  string `json:"preferred_given_name,omitempty"`
-	PreferredFamilyName string `json:"preferred_family_name,omitempty"`
-	DisplayName         string `json:"display_name,omitempty"`
-}
-
 type WorkerUser struct {
 	ID                string        `json:"id"`
 	CreatedAt         string        `json:"created_at"`
 	UpdatedAt         string        `json:"updated_at"`
 	Active            bool          `json:"active,omitempty"`
 	Username          string        `json:"username,omitempty"`
-	Name              WorkerName    `json:"name,omitempty"`
+	Name              Name          `json:"name,omitempty"`
 	Emails            []Email       `json:"emails,omitempty"`
 	PhoneNumbers      []PhoneNumber `json:"phone_numbers,omitempty"`
 	Addresses         []Address     `json:"addresses,omitempty"`

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -302,3 +302,17 @@ type WorkersResponse struct {
 	Results  []Worker `json:"results"`
 	NextLink string   `json:"next_link,omitempty"`
 }
+
+type WorkLocation struct {
+	ID        string   `json:"id"`
+	CreatedAt string   `json:"created_at"`
+	UpdatedAt string   `json:"updated_at"`
+	Name      string   `json:"name"`
+	Address   *Address `json:"address,omitempty"`
+}
+
+type WorkLocationsResponse struct {
+	Meta     Meta           `json:"__meta"`
+	Results  []WorkLocation `json:"results"`
+	NextLink string         `json:"next_link,omitempty"`
+}

--- a/pkg/client/urls.go
+++ b/pkg/client/urls.go
@@ -1,9 +1,9 @@
 package client
 
 const (
-	BaseURL    = "https://rest.ripplingapis.com"
-	UsersURL   = BaseURL + "/users"
-	TeamsURL   = BaseURL + "/teams"
-	WorkersURL        = BaseURL + "/workers"
-	WorkLocationsURL  = BaseURL + "/work-locations"
+	BaseURL          = "https://rest.ripplingapis.com"
+	UsersURL         = BaseURL + "/users"
+	TeamsURL         = BaseURL + "/teams"
+	WorkersURL       = BaseURL + "/workers"
+	WorkLocationsURL = BaseURL + "/work-locations"
 )

--- a/pkg/client/urls.go
+++ b/pkg/client/urls.go
@@ -1,9 +1,10 @@
 package client
 
 const (
-	BaseURL          = "https://rest.ripplingapis.com"
-	UsersURL         = BaseURL + "/users"
-	TeamsURL         = BaseURL + "/teams"
-	WorkersURL       = BaseURL + "/workers"
-	WorkLocationsURL = BaseURL + "/work-locations"
+	DefaultBaseURL = "https://rest.ripplingapis.com"
+
+	usersPath         = "/users"
+	teamsPath         = "/teams"
+	workersPath       = "/workers"
+	workLocationsPath = "/work-locations"
 )

--- a/pkg/client/urls.go
+++ b/pkg/client/urls.go
@@ -4,5 +4,6 @@ const (
 	BaseURL    = "https://rest.ripplingapis.com"
 	UsersURL   = BaseURL + "/users"
 	TeamsURL   = BaseURL + "/teams"
-	WorkersURL = BaseURL + "/workers"
+	WorkersURL        = BaseURL + "/workers"
+	WorkLocationsURL  = BaseURL + "/work-locations"
 )

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Rippling struct {
 	ExpandDepartment bool `mapstructure:"expand-department"`
 	ExpandEmploymentType bool `mapstructure:"expand-employment-type"`
 	ExpandLevel bool `mapstructure:"expand-level"`
+	ExpandWorkLocations bool `mapstructure:"expand-work-locations"`
 }
 
 func (c *Rippling) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,6 +5,7 @@ import "reflect"
 
 type Rippling struct {
 	ApiToken string `mapstructure:"api-token"`
+	BaseUrl string `mapstructure:"base-url"`
 	ExpandDepartment bool `mapstructure:"expand-department"`
 	ExpandEmploymentType bool `mapstructure:"expand-employment-type"`
 	ExpandLevel bool `mapstructure:"expand-level"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,11 +24,16 @@ var (
 		field.WithDisplayName("Expand level"),
 		field.WithDescription("Include level data in worker sync. Requires the levels.read scope."),
 	)
+	ExpandWorkLocations = field.BoolField("expand-work-locations",
+		field.WithDisplayName("Expand work locations"),
+		field.WithDescription("Include work location name and address in user profiles. Requires the work-locations.read scope."),
+	)
 	ConfigurationFields = []field.SchemaField{
 		ApiToken,
 		ExpandDepartment,
 		ExpandEmploymentType,
 		ExpandLevel,
+		ExpandWorkLocations,
 	}
 
 	// FieldRelationships defines relationships between the ConfigurationFields that can be automatically validated.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/conductorone/baton-rippling/pkg/client"
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
@@ -11,6 +12,12 @@ var (
 		field.WithDescription("The API token for the Rippling connector. This is used to authenticate API requests."),
 		field.WithRequired(true),
 		field.WithIsSecret(true),
+	)
+	BaseURL = field.StringField("base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("The base URL for the Rippling API."),
+		field.WithDefaultValue(client.DefaultBaseURL),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	ExpandDepartment = field.BoolField("expand-department",
 		field.WithDisplayName("Expand department"),
@@ -30,6 +37,7 @@ var (
 	)
 	ConfigurationFields = []field.SchemaField{
 		ApiToken,
+		BaseURL,
 		ExpandDepartment,
 		ExpandEmploymentType,
 		ExpandLevel,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Connector struct {
-	client *client.Client
+	client               *client.Client
+	expandWorkLocations  bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client),
+		newUserBuilder(d.client, d.expandWorkLocations),
 		newTeamBuilder(d.client),
 	}
 }
@@ -44,12 +45,13 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiToken string, expandOpts client.ExpandOptions) (*Connector, error) {
+func New(ctx context.Context, apiToken string, expandOpts client.ExpandOptions, expandWorkLocations bool) (*Connector, error) {
 	c, err := client.New(ctx, apiToken, expandOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 	return &Connector{
-		client: c,
+		client:              c,
+		expandWorkLocations: expandWorkLocations,
 	}, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -48,7 +48,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 func New(ctx context.Context, apiToken string, baseURL string, expandOpts client.ExpandOptions, expandWorkLocations bool) (*Connector, error) {
 	c, err := client.New(ctx, apiToken, baseURL, expandOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %w", err)
+		return nil, fmt.Errorf("baton-rippling: failed to create client: %w", err)
 	}
 	return &Connector{
 		client:              c,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -45,8 +45,8 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiToken string, expandOpts client.ExpandOptions, expandWorkLocations bool) (*Connector, error) {
-	c, err := client.New(ctx, apiToken, expandOpts)
+func New(ctx context.Context, apiToken string, baseURL string, expandOpts client.ExpandOptions, expandWorkLocations bool) (*Connector, error) {
+	c, err := client.New(ctx, apiToken, baseURL, expandOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -75,12 +75,15 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		addrMap := map[string]any{}
 		if addr.Locality != "" {
 			addrMap["locality"] = addr.Locality
+			profile["locality"] = addr.Locality
 		}
 		if addr.Region != "" {
 			addrMap["region"] = addr.Region
+			profile["region"] = addr.Region
 		}
 		if addr.Country != "" {
 			addrMap["country"] = addr.Country
+			profile["country"] = addr.Country
 		}
 		if addr.StreetAddress != "" {
 			addrMap["street_address"] = addr.StreetAddress
@@ -90,15 +93,6 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		}
 		if len(addrMap) > 0 {
 			profile["address"] = addrMap
-		}
-		if addr.Locality != "" {
-			profile["locality"] = addr.Locality
-		}
-		if addr.Region != "" {
-			profile["region"] = addr.Region
-		}
-		if addr.Country != "" {
-			profile["country"] = addr.Country
 		}
 		break
 	}
@@ -164,12 +158,21 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 			addrMap := map[string]any{}
 			if workLocation.Address.Locality != "" {
 				addrMap["locality"] = workLocation.Address.Locality
+				// Work location address takes precedence over user WORK address
+				// for top-level locality/region/country fields.
+				profile["locality"] = workLocation.Address.Locality
 			}
 			if workLocation.Address.Region != "" {
 				addrMap["region"] = workLocation.Address.Region
+				// Work location address takes precedence over user WORK address
+				// for top-level locality/region/country fields.
+				profile["region"] = workLocation.Address.Region
 			}
 			if workLocation.Address.Country != "" {
 				addrMap["country"] = workLocation.Address.Country
+				// Work location address takes precedence over user WORK address
+				// for top-level locality/region/country fields.
+				profile["country"] = workLocation.Address.Country
 			}
 			if workLocation.Address.StreetAddress != "" {
 				addrMap["street_address"] = workLocation.Address.StreetAddress
@@ -179,15 +182,6 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 			}
 			if len(addrMap) > 0 {
 				profile["work_location_address"] = addrMap
-			}
-			if workLocation.Address.Locality != "" {
-				profile["locality"] = workLocation.Address.Locality
-			}
-			if workLocation.Address.Region != "" {
-				profile["region"] = workLocation.Address.Region
-			}
-			if workLocation.Address.Country != "" {
-				profile["country"] = workLocation.Address.Country
 			}
 		}
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -67,40 +67,31 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		profile["preferred_family_name"] = user.Name.PreferredFamilyName
 	}
 
-	// Address fields from User, grouped by type
-	if len(user.Addresses) > 0 {
-		addresses := map[string]any{}
-		for _, addr := range user.Addresses {
-			addrType := strings.ToLower(addr.Type)
-			if addrType == "" {
-				addrType = "other"
-			}
-			if _, exists := addresses[addrType]; exists {
-				continue // keep first of each type
-			}
-			addrMap := map[string]any{}
-			if addr.Locality != "" {
-				addrMap["locality"] = addr.Locality
-			}
-			if addr.Region != "" {
-				addrMap["region"] = addr.Region
-			}
-			if addr.Country != "" {
-				addrMap["country"] = addr.Country
-			}
-			if addr.StreetAddress != "" {
-				addrMap["street_address"] = addr.StreetAddress
-			}
-			if addr.PostalCode != "" {
-				addrMap["postal_code"] = addr.PostalCode
-			}
-			if len(addrMap) > 0 {
-				addresses[addrType] = addrMap
-			}
+	// Work address from User (first WORK-type address wins)
+	for _, addr := range user.Addresses {
+		if !strings.EqualFold(addr.Type, workEmailType) {
+			continue
 		}
-		if len(addresses) > 0 {
-			profile["addresses"] = addresses
+		addrMap := map[string]any{}
+		if addr.Locality != "" {
+			addrMap["locality"] = addr.Locality
 		}
+		if addr.Region != "" {
+			addrMap["region"] = addr.Region
+		}
+		if addr.Country != "" {
+			addrMap["country"] = addr.Country
+		}
+		if addr.StreetAddress != "" {
+			addrMap["street_address"] = addr.StreetAddress
+		}
+		if addr.PostalCode != "" {
+			addrMap["postal_code"] = addr.PostalCode
+		}
+		if len(addrMap) > 0 {
+			profile["address"] = addrMap
+		}
+		break
 	}
 
 	// Add worker-related attributes if available

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -317,6 +317,27 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 		return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to get workers from session store: %w", err)
 	}
 
+	// Batch-fetch work locations for all workers on this page.
+	var workLocations map[string]client.WorkLocation
+	if o.expandWorkLocations {
+		locationIDs := make([]string, 0)
+		seen := make(map[string]bool)
+		for _, user := range usersResponse.Results {
+			if worker, found := workers[user.ID]; found {
+				if worker.Location != nil && worker.Location.WorkLocationID != "" && !seen[worker.Location.WorkLocationID] {
+					locationIDs = append(locationIDs, worker.Location.WorkLocationID)
+					seen[worker.Location.WorkLocationID] = true
+				}
+			}
+		}
+		if len(locationIDs) > 0 {
+			workLocations, err = session.GetManyJSON[client.WorkLocation](ctx, ss, locationIDs, sessions.WithPrefix(workLocationsSessionPrefix))
+			if err != nil {
+				return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to get work locations from session store: %w", err)
+			}
+		}
+	}
+
 	rv := make([]*v2.Resource, 0, len(usersResponse.Results))
 	for _, user := range usersResponse.Results {
 		var workerPtr *client.Worker
@@ -326,12 +347,8 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 
 		var workLocationPtr *client.WorkLocation
 		if o.expandWorkLocations && workerPtr != nil && workerPtr.Location != nil && workerPtr.Location.WorkLocationID != "" {
-			loc, found, locErr := session.GetJSON[client.WorkLocation](ctx, ss, workerPtr.Location.WorkLocationID, sessions.WithPrefix(workLocationsSessionPrefix))
-			if locErr != nil {
-				return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to get work location from session store: %w", locErr)
-			}
-			if found {
-				workLocationPtr = &loc
+			if wl, ok := workLocations[workerPtr.Location.WorkLocationID]; ok {
+				workLocationPtr = &wl
 			}
 		}
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -43,6 +43,62 @@ func userResource(user client.User, worker *client.Worker) (*v2.Resource, error)
 		"locale":   user.Locale,
 	}
 
+	// Name fields from User
+	if user.Name.GivenName != "" {
+		profile["given_name"] = user.Name.GivenName
+	}
+	if user.Name.FamilyName != "" {
+		profile["family_name"] = user.Name.FamilyName
+	}
+	if user.Name.MiddleName != "" {
+		profile["middle_name"] = user.Name.MiddleName
+	}
+	if user.Name.Formatted != "" {
+		profile["formatted_name"] = user.Name.Formatted
+	}
+	if user.Name.PreferredGivenName != "" {
+		profile["preferred_given_name"] = user.Name.PreferredGivenName
+	}
+	if user.Name.PreferredFamilyName != "" {
+		profile["preferred_family_name"] = user.Name.PreferredFamilyName
+	}
+
+	// Address fields from User, grouped by type
+	if len(user.Addresses) > 0 {
+		addresses := map[string]any{}
+		for _, addr := range user.Addresses {
+			addrType := strings.ToLower(addr.Type)
+			if addrType == "" {
+				addrType = "other"
+			}
+			if _, exists := addresses[addrType]; exists {
+				continue // keep first of each type
+			}
+			addrMap := map[string]any{}
+			if addr.Locality != "" {
+				addrMap["locality"] = addr.Locality
+			}
+			if addr.Region != "" {
+				addrMap["region"] = addr.Region
+			}
+			if addr.Country != "" {
+				addrMap["country"] = addr.Country
+			}
+			if addr.StreetAddress != "" {
+				addrMap["street_address"] = addr.StreetAddress
+			}
+			if addr.PostalCode != "" {
+				addrMap["postal_code"] = addr.PostalCode
+			}
+			if len(addrMap) > 0 {
+				addresses[addrType] = addrMap
+			}
+		}
+		if len(addresses) > 0 {
+			profile["addresses"] = addresses
+		}
+	}
+
 	// Add worker-related attributes if available
 	if worker != nil {
 		// Employment information
@@ -83,6 +139,9 @@ func userResource(user client.User, worker *client.Worker) (*v2.Resource, error)
 		}
 
 		// Department information
+		if worker.DepartmentID != "" {
+			profile["department_id"] = worker.DepartmentID
+		}
 		if worker.Department != nil && worker.Department.Name != "" {
 			profile["department"] = worker.Department.Name
 		}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -215,6 +215,7 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		resource.WithUserProfile(profile),
 		resource.WithCreatedAt(createdAt),
 		resource.WithStatus(userStatus),
+		resource.WithUserLogin(user.Username),
 	}
 
 	email := getWorkEmail(user.Emails)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -117,20 +117,8 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		}
 
 		// Employment type information
-		if worker.EmploymentType != nil {
-			employmentType := map[string]any{}
-			if worker.EmploymentType.Label != "" {
-				employmentType["label"] = worker.EmploymentType.Label
-			}
-			if worker.EmploymentType.Name != "" {
-				employmentType["name"] = worker.EmploymentType.Name
-			}
-			if worker.EmploymentType.Type != "" {
-				employmentType["type"] = worker.EmploymentType.Type
-			}
-			if len(employmentType) > 0 {
-				profile["employment_type"] = employmentType
-			}
+		if worker.EmploymentType != nil && worker.EmploymentType.Type != "" {
+			profile["employment_type"] = worker.EmploymentType.Type
 		}
 
 		// Department information

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -223,7 +223,7 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 	}
 
 	return resource.NewUserResource(
-		user.Name.DisplayName,
+		user.DisplayName,
 		userResourceType,
 		user.ID,
 		userOpts,

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -117,8 +117,16 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		}
 
 		// Employment type information
-		if worker.EmploymentType != nil && worker.EmploymentType.Type != "" {
-			profile["employment_type"] = worker.EmploymentType.Type
+		if worker.EmploymentType != nil {
+			if worker.EmploymentType.Type != "" {
+				profile["employment_type"] = worker.EmploymentType.Type
+			}
+			if worker.EmploymentType.Name != "" {
+				profile["employment_name"] = worker.EmploymentType.Name
+			}
+			if worker.EmploymentType.Label != "" {
+				profile["employment_label"] = worker.EmploymentType.Label
+			}
 		}
 
 		// Department information

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const workEmailType = "WORK"
+const workType = "WORK"
 const workersSessionPrefix = "workers"
 const workLocationsSessionPrefix = "work_locations"
 
@@ -32,8 +32,8 @@ const (
 )
 
 type userBuilder struct {
-	client             *client.Client
-	expandWorkLocations  bool
+	client              *client.Client
+	expandWorkLocations bool
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -69,7 +69,7 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 
 	// Work address from User (first WORK-type address wins)
 	for _, addr := range user.Addresses {
-		if !strings.EqualFold(addr.Type, workEmailType) {
+		if !strings.EqualFold(addr.Type, workType) {
 			continue
 		}
 		addrMap := map[string]any{}
@@ -217,7 +217,7 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 
 	email := getWorkEmail(user.Emails)
 	if email != nil {
-		userOpts = append(userOpts, resource.WithEmail(email.Value, strings.EqualFold(email.Type, workEmailType)))
+		userOpts = append(userOpts, resource.WithEmail(email.Value, strings.EqualFold(email.Type, workType)))
 	}
 
 	return resource.NewUserResource(
@@ -374,7 +374,7 @@ func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, opts resource.
 func getWorkEmail(emails []client.Email) *client.Email {
 	var workEmail *client.Email
 	for _, e := range emails {
-		if strings.EqualFold(e.Type, workEmailType) {
+		if strings.EqualFold(e.Type, workType) {
 			return &e
 		}
 
@@ -428,7 +428,7 @@ func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.
 
 func newUserBuilder(client *client.Client, expandWorkLocations bool) *userBuilder {
 	return &userBuilder{
-		client:            client,
+		client:              client,
 		expandWorkLocations: expandWorkLocations,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -19,24 +19,28 @@ import (
 
 const workEmailType = "WORK"
 const workersSessionPrefix = "workers"
+const workLocationsSessionPrefix = "work_locations"
 
-// Page token prefixes to distinguish the two phases of user List():
-// Phase 1 pages through workers, storing each page in the session store.
-// Phase 2 pages through users, looking up cached workers per-user.
+// Page token prefixes to distinguish the phases of user List():
+// Phase 1 (optional): pages through work locations, storing each in the session store.
+// Phase 2: pages through workers, storing each page in the session store.
+// Phase 3: pages through users, looking up cached workers and locations per-user.
 const (
-	workersPagePrefix = "w:"
-	usersPagePrefix   = "u:"
+	locationsPagePrefix = "l:"
+	workersPagePrefix   = "w:"
+	usersPagePrefix     = "u:"
 )
 
 type userBuilder struct {
-	client *client.Client
+	client             *client.Client
+	expandWorkLocations  bool
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return userResourceType
 }
 
-func userResource(user client.User, worker *client.Worker) (*v2.Resource, error) {
+func userResource(user client.User, worker *client.Worker, workLocation *client.WorkLocation) (*v2.Resource, error) {
 	profile := map[string]any{
 		"username": user.Username,
 		"active":   user.Active,
@@ -166,6 +170,34 @@ func userResource(user client.User, worker *client.Worker) (*v2.Resource, error)
 		}
 	}
 
+	// Work location details (from separate API call)
+	if workLocation != nil {
+		if workLocation.Name != "" {
+			profile["work_location_name"] = workLocation.Name
+		}
+		if workLocation.Address != nil {
+			addrMap := map[string]any{}
+			if workLocation.Address.Locality != "" {
+				addrMap["locality"] = workLocation.Address.Locality
+			}
+			if workLocation.Address.Region != "" {
+				addrMap["region"] = workLocation.Address.Region
+			}
+			if workLocation.Address.Country != "" {
+				addrMap["country"] = workLocation.Address.Country
+			}
+			if workLocation.Address.StreetAddress != "" {
+				addrMap["street_address"] = workLocation.Address.StreetAddress
+			}
+			if workLocation.Address.PostalCode != "" {
+				addrMap["postal_code"] = workLocation.Address.PostalCode
+			}
+			if len(addrMap) > 0 {
+				profile["work_location_address"] = addrMap
+			}
+		}
+	}
+
 	// convert to time.Time
 	createdAt, err := time.Parse(time.RFC3339, user.CreatedAt)
 	if err != nil {
@@ -200,6 +232,41 @@ func userResource(user client.User, worker *client.Worker) (*v2.Resource, error)
 		user.ID,
 		userOpts,
 	)
+}
+
+// listWorkLocationPage fetches one page of work locations from the API and
+// stores them in the session store. Returns no resources — this phase only populates the cache.
+func (o *userBuilder) listWorkLocationPage(ctx context.Context, pageToken string, ss sessions.SessionStore) ([]*v2.Resource, *resource.SyncOpResults, error) {
+	var annos annotations.Annotations
+	resp, ratelimitData, err := o.client.ListWorkLocations(ctx, pageToken)
+	annos = *annos.WithRateLimiting(ratelimitData)
+	if err != nil {
+		return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to list work locations: %w", err)
+	}
+
+	toStore := make(map[string]client.WorkLocation, len(resp.Results))
+	for _, loc := range resp.Results {
+		if loc.ID != "" {
+			toStore[loc.ID] = loc
+		}
+	}
+	if len(toStore) > 0 {
+		if err := session.SetManyJSON(ctx, ss, toStore, sessions.WithPrefix(workLocationsSessionPrefix)); err != nil {
+			return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to store work locations in session store: %w", err)
+		}
+	}
+
+	// If more pages remain, stay in the locations phase.
+	// Otherwise transition to the workers phase.
+	nextToken := workersPagePrefix
+	if resp.NextLink != "" {
+		nextToken = locationsPagePrefix + resp.NextLink
+	}
+
+	return nil, &resource.SyncOpResults{
+		NextPageToken: nextToken,
+		Annotations:   annos,
+	}, nil
 }
 
 // listWorkerPage fetches one page of workers from the API and stores them in
@@ -263,7 +330,18 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 			workerPtr = &worker
 		}
 
-		r, err := userResource(user, workerPtr)
+		var workLocationPtr *client.WorkLocation
+		if o.expandWorkLocations && workerPtr != nil && workerPtr.Location != nil && workerPtr.Location.WorkLocationID != "" {
+			loc, found, locErr := session.GetJSON[client.WorkLocation](ctx, ss, workerPtr.Location.WorkLocationID, sessions.WithPrefix(workLocationsSessionPrefix))
+			if locErr != nil {
+				return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to get work location from session store: %w", locErr)
+			}
+			if found {
+				workLocationPtr = &loc
+			}
+		}
+
+		r, err := userResource(user, workerPtr, workLocationPtr)
 		if err != nil {
 			return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to convert user %s to resource: %w", user.ID, err)
 		}
@@ -285,12 +363,16 @@ func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, opts resource.
 	token := opts.PageToken.Token
 
 	switch {
+	case o.expandWorkLocations && (token == "" || strings.HasPrefix(token, locationsPagePrefix)):
+		// Phase 1 (optional): page through work locations, storing each in the session store.
+		return o.listWorkLocationPage(ctx, strings.TrimPrefix(token, locationsPagePrefix), opts.Session)
+
 	case token == "" || strings.HasPrefix(token, workersPagePrefix):
-		// Phase 1: page through workers, storing each page in the session store.
+		// Phase 2: page through workers, storing each page in the session store.
 		return o.listWorkerPage(ctx, strings.TrimPrefix(token, workersPagePrefix), opts.Session)
 
 	default:
-		// Phase 2: page through users, looking up cached workers per-user.
+		// Phase 3: page through users, looking up cached workers and locations per-user.
 		return o.listUserPage(ctx, strings.TrimPrefix(token, usersPagePrefix), opts.Session)
 	}
 }
@@ -350,8 +432,9 @@ func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.
 	return rv, nil, nil
 }
 
-func newUserBuilder(client *client.Client) *userBuilder {
+func newUserBuilder(client *client.Client, expandWorkLocations bool) *userBuilder {
 	return &userBuilder{
-		client: client,
+		client:            client,
+		expandWorkLocations: expandWorkLocations,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -91,6 +91,15 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		if len(addrMap) > 0 {
 			profile["address"] = addrMap
 		}
+		if addr.Locality != "" {
+			profile["locality"] = addr.Locality
+		}
+		if addr.Region != "" {
+			profile["region"] = addr.Region
+		}
+		if addr.Country != "" {
+			profile["country"] = addr.Country
+		}
 		break
 	}
 
@@ -111,9 +120,6 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		}
 		if worker.WorkEmail != "" {
 			profile["work_email"] = worker.WorkEmail
-		}
-		if worker.Country != "" {
-			profile["country"] = worker.Country
 		}
 
 		// Employment type information
@@ -173,6 +179,15 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 			}
 			if len(addrMap) > 0 {
 				profile["work_location_address"] = addrMap
+			}
+			if workLocation.Address.Locality != "" {
+				profile["locality"] = workLocation.Address.Locality
+			}
+			if workLocation.Address.Region != "" {
+				profile["region"] = workLocation.Address.Region
+			}
+			if workLocation.Address.Country != "" {
+				profile["country"] = workLocation.Address.Country
 			}
 		}
 	}

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestUserResource_NoWorker(t *testing.T) {
 	user := client.User{
-		ID:        "user-1",
-		Username:  "alice",
-		Active:    true,
-		Locale:    "en-US",
-		CreatedAt: "2024-01-01T00:00:00Z",
+		ID:          "user-1",
+		Username:    "alice",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Alice Smith",
 		Name: client.Name{
-			DisplayName:         "Alice Smith",
 			GivenName:           "Alice",
 			FamilyName:          "Smith",
 			Formatted:           "Alice Smith",
@@ -37,16 +37,16 @@ func TestUserResource_NoWorker(t *testing.T) {
 
 func TestUserResource_WithFullWorker(t *testing.T) {
 	user := client.User{
-		ID:        "user-2",
-		Username:  "bob",
-		Active:    true,
-		Locale:    "en-US",
-		CreatedAt: "2024-06-15T12:00:00Z",
+		ID:          "user-2",
+		Username:    "bob",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-06-15T12:00:00Z",
+		DisplayName: "Bob Jones",
 		Name: client.Name{
-			DisplayName: "Bob Jones",
-			GivenName:   "Bob",
-			FamilyName:  "Jones",
-			MiddleName:  "Michael",
+			GivenName:  "Bob",
+			FamilyName: "Jones",
+			MiddleName: "Michael",
 		},
 		Emails: []client.Email{{Value: "bob@example.com"}},
 		Addresses: []client.Address{
@@ -107,7 +107,7 @@ func TestUserResource_WorkerWithNilNestedStructs(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-03-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Carol Lee"},
+		DisplayName: "Carol Lee",
 		Emails:    []client.Email{{Value: "carol@example.com"}},
 	}
 	worker := &client.Worker{
@@ -134,7 +134,7 @@ func TestUserResource_WorkerEmptyStringsNotIncluded(t *testing.T) {
 		Active:    false,
 		Locale:    "en-US",
 		CreatedAt: "2024-02-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Dave Kim"},
+		DisplayName: "Dave Kim",
 		Emails:    []client.Email{{Value: "dave@example.com"}},
 	}
 	worker := &client.Worker{
@@ -164,7 +164,7 @@ func TestUserResource_NoEmails(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Eve Wu"},
+		DisplayName: "Eve Wu",
 		Emails:    nil,
 	}
 
@@ -180,8 +180,8 @@ func TestUserResource_ProfileNameAndAddressFields(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
+		DisplayName: "Grace Hopper",
 		Name: client.Name{
-			DisplayName:         "Grace Hopper",
 			GivenName:           "Grace",
 			FamilyName:          "Hopper",
 			MiddleName:          "Brewster",
@@ -256,7 +256,7 @@ func TestUserResource_AddressWithNonWorkType(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Hank Hill"},
+		DisplayName: "Hank Hill",
 		Emails:    []client.Email{{Value: "hank@example.com"}},
 		Addresses: []client.Address{
 			{
@@ -289,7 +289,7 @@ func TestUserResource_AddressAllFieldsEmpty(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Irene Adler"},
+		DisplayName: "Irene Adler",
 		Emails:    []client.Email{{Value: "irene@example.com"}},
 		Addresses: []client.Address{
 			{
@@ -311,7 +311,7 @@ func TestUserResource_WithWorkLocation(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Kate Walsh"},
+		DisplayName: "Kate Walsh",
 		Emails:    []client.Email{{Value: "kate@example.com"}},
 	}
 	worker := &client.Worker{
@@ -366,7 +366,7 @@ func TestUserResource_NilWorkLocation(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Leo Park"},
+		DisplayName: "Leo Park",
 		Emails:    []client.Email{{Value: "leo@example.com"}},
 	}
 	worker := &client.Worker{
@@ -387,7 +387,7 @@ func TestUserResource_WorkLocationNameOnly(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Maya Chen"},
+		DisplayName: "Maya Chen",
 		Emails:    []client.Email{{Value: "maya@example.com"}},
 	}
 	worker := &client.Worker{
@@ -422,7 +422,7 @@ func TestUserResource_InvalidCreatedAt(t *testing.T) {
 		Username:  "frank",
 		Active:    true,
 		CreatedAt: "not-a-date",
-		Name:      client.Name{DisplayName: "Frank"},
+		DisplayName: "Frank",
 	}
 
 	_, err := userResource(user, nil, nil)

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -14,8 +14,15 @@ func TestUserResource_NoWorker(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-01-01T00:00:00Z",
-		Name:      client.Name{DisplayName: "Alice Smith"},
-		Emails:    []client.Email{{Value: "alice@example.com"}},
+		Name: client.Name{
+			DisplayName:         "Alice Smith",
+			GivenName:           "Alice",
+			FamilyName:          "Smith",
+			Formatted:           "Alice Smith",
+			PreferredGivenName:  "Ali",
+			PreferredFamilyName: "Smith",
+		},
+		Emails: []client.Email{{Value: "alice@example.com"}},
 	}
 
 	r, err := userResource(user, nil)
@@ -34,20 +41,42 @@ func TestUserResource_WithFullWorker(t *testing.T) {
 		Active:    true,
 		Locale:    "en-US",
 		CreatedAt: "2024-06-15T12:00:00Z",
-		Name:      client.Name{DisplayName: "Bob Jones"},
-		Emails:    []client.Email{{Value: "bob@example.com"}},
+		Name: client.Name{
+			DisplayName: "Bob Jones",
+			GivenName:   "Bob",
+			FamilyName:  "Jones",
+			MiddleName:  "Michael",
+		},
+		Emails: []client.Email{{Value: "bob@example.com"}},
+		Addresses: []client.Address{
+			{
+				Type:          "WORK",
+				Locality:      "San Francisco",
+				Region:        "CA",
+				Country:       "US",
+				StreetAddress: "123 Main St",
+				PostalCode:    "94105",
+			},
+			{
+				Type:     "HOME",
+				Locality: "Oakland",
+				Region:   "CA",
+				Country:  "US",
+			},
+		},
 	}
 	worker := &client.Worker{
-		ID:        "worker-2",
-		UserID:    "user-2",
-		Title:     "Senior Engineer",
-		Status:    "ACTIVE",
-		StartDate: "2023-01-15",
-		EndDate:   "",
-		WorkEmail: "bob@company.com",
-		Country:   "US",
-		IsManager: true,
-		ManagerID: "worker-1",
+		ID:           "worker-2",
+		UserID:       "user-2",
+		Title:        "Senior Engineer",
+		Status:       "ACTIVE",
+		StartDate:    "2023-01-15",
+		EndDate:      "",
+		WorkEmail:    "bob@company.com",
+		Country:      "US",
+		IsManager:    true,
+		ManagerID:    "worker-1",
+		DepartmentID: "dept-eng-1",
 		EmploymentType: &client.EmploymentType{
 			Label: "Full-time",
 			Name:  "FULL_TIME",
@@ -141,6 +170,116 @@ func TestUserResource_NoEmails(t *testing.T) {
 	r, err := userResource(user, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Eve Wu", r.DisplayName)
+}
+
+func TestUserResource_ProfileNameAndAddressFields(t *testing.T) {
+	user := client.User{
+		ID:        "user-7",
+		Username:  "grace",
+		Active:    true,
+		Locale:    "en-US",
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Name: client.Name{
+			DisplayName:         "Grace Hopper",
+			GivenName:           "Grace",
+			FamilyName:          "Hopper",
+			MiddleName:          "Brewster",
+			Formatted:           "Grace Brewster Hopper",
+			PreferredGivenName:  "Grace",
+			PreferredFamilyName: "Hopper",
+		},
+		Emails: []client.Email{{Value: "grace@example.com"}},
+		Addresses: []client.Address{
+			{
+				Type:          "WORK",
+				Locality:      "Arlington",
+				Region:        "VA",
+				Country:       "US",
+				StreetAddress: "1400 Defense Pentagon",
+				PostalCode:    "22202",
+			},
+			{
+				Type:     "HOME",
+				Locality: "New York",
+				Region:   "NY",
+				Country:  "US",
+			},
+			// Second WORK address should be ignored (keep first)
+			{
+				Type:     "WORK",
+				Locality: "Washington",
+				Region:   "DC",
+				Country:  "US",
+			},
+		},
+	}
+	worker := &client.Worker{
+		ID:           "worker-7",
+		UserID:       "user-7",
+		DepartmentID: "dept-42",
+		Status:       "ACTIVE",
+		Department:   &client.Department{Name: "R&D"},
+	}
+
+	r, err := userResource(user, worker)
+	assert.NoError(t, err)
+
+	// Extract profile from annotations
+	userTrait := r.GetAnnotations()
+	assert.NotNil(t, userTrait)
+
+	// Verify the resource was created with the right display name
+	assert.Equal(t, "Grace Hopper", r.DisplayName)
+
+	// Verify the resource was created successfully (profile is in annotations,
+	// we trust the implementation above sets them correctly based on the code).
+	assert.Equal(t, "user-7", r.Id.Resource)
+}
+
+func TestUserResource_AddressWithEmptyType(t *testing.T) {
+	user := client.User{
+		ID:        "user-8",
+		Username:  "hank",
+		Active:    true,
+		Locale:    "en-US",
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Name:      client.Name{DisplayName: "Hank Hill"},
+		Emails:    []client.Email{{Value: "hank@example.com"}},
+		Addresses: []client.Address{
+			{
+				Type:     "",
+				Locality: "Arlen",
+				Region:   "TX",
+				Country:  "US",
+			},
+		},
+	}
+
+	r, err := userResource(user, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hank Hill", r.DisplayName)
+}
+
+func TestUserResource_AddressAllFieldsEmpty(t *testing.T) {
+	user := client.User{
+		ID:        "user-9",
+		Username:  "irene",
+		Active:    true,
+		Locale:    "en-US",
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Name:      client.Name{DisplayName: "Irene Adler"},
+		Emails:    []client.Email{{Value: "irene@example.com"}},
+		Addresses: []client.Address{
+			{
+				Type: "WORK",
+				// All address fields empty
+			},
+		},
+	}
+
+	r, err := userResource(user, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Irene Adler", r.DisplayName)
 }
 
 func TestUserResource_InvalidCreatedAt(t *testing.T) {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -25,7 +25,7 @@ func TestUserResource_NoWorker(t *testing.T) {
 		Emails: []client.Email{{Value: "alice@example.com"}},
 	}
 
-	r, err := userResource(user, nil)
+	r, err := userResource(user, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Alice Smith", r.DisplayName)
 	assert.Equal(t, "user-1", r.Id.Resource)
@@ -93,7 +93,7 @@ func TestUserResource_WithFullWorker(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, worker)
+	r, err := userResource(user, worker, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Bob Jones", r.DisplayName)
 	assert.Equal(t, "user-2", r.Id.Resource)
@@ -121,7 +121,7 @@ func TestUserResource_WorkerWithNilNestedStructs(t *testing.T) {
 		Location:       nil,
 	}
 
-	r, err := userResource(user, worker)
+	r, err := userResource(user, worker, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Carol Lee", r.DisplayName)
 }
@@ -151,7 +151,7 @@ func TestUserResource_WorkerEmptyStringsNotIncluded(t *testing.T) {
 		Location:   &client.Location{WorkLocationID: ""},
 	}
 
-	r, err := userResource(user, worker)
+	r, err := userResource(user, worker, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Dave Kim", r.DisplayName)
 }
@@ -167,7 +167,7 @@ func TestUserResource_NoEmails(t *testing.T) {
 		Emails:    nil,
 	}
 
-	r, err := userResource(user, nil)
+	r, err := userResource(user, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Eve Wu", r.DisplayName)
 }
@@ -221,7 +221,7 @@ func TestUserResource_ProfileNameAndAddressFields(t *testing.T) {
 		Department:   &client.Department{Name: "R&D"},
 	}
 
-	r, err := userResource(user, worker)
+	r, err := userResource(user, worker, nil)
 	assert.NoError(t, err)
 
 	// Extract profile from annotations
@@ -255,7 +255,7 @@ func TestUserResource_AddressWithEmptyType(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, nil)
+	r, err := userResource(user, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Hank Hill", r.DisplayName)
 }
@@ -277,9 +277,90 @@ func TestUserResource_AddressAllFieldsEmpty(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, nil)
+	r, err := userResource(user, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Irene Adler", r.DisplayName)
+}
+
+func TestUserResource_WithWorkLocation(t *testing.T) {
+	user := client.User{
+		ID:        "user-10",
+		Username:  "kate",
+		Active:    true,
+		Locale:    "en-US",
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Name:      client.Name{DisplayName: "Kate Walsh"},
+		Emails:    []client.Email{{Value: "kate@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-10",
+		UserID: "user-10",
+		Status: "ACTIVE",
+		Location: &client.Location{
+			WorkLocationID: "loc-nyc",
+		},
+	}
+	workLocation := &client.WorkLocation{
+		ID:   "loc-nyc",
+		Name: "New York Office",
+		Address: &client.Address{
+			StreetAddress: "350 Fifth Ave",
+			Locality:      "New York",
+			Region:        "NY",
+			PostalCode:    "10118",
+			Country:       "US",
+		},
+	}
+
+	r, err := userResource(user, worker, workLocation)
+	assert.NoError(t, err)
+	assert.Equal(t, "Kate Walsh", r.DisplayName)
+}
+
+func TestUserResource_NilWorkLocation(t *testing.T) {
+	user := client.User{
+		ID:        "user-11",
+		Username:  "leo",
+		Active:    true,
+		Locale:    "en-US",
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Name:      client.Name{DisplayName: "Leo Park"},
+		Emails:    []client.Email{{Value: "leo@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-11",
+		UserID: "user-11",
+		Status: "ACTIVE",
+	}
+
+	r, err := userResource(user, worker, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Leo Park", r.DisplayName)
+}
+
+func TestUserResource_WorkLocationNameOnly(t *testing.T) {
+	user := client.User{
+		ID:        "user-12",
+		Username:  "maya",
+		Active:    true,
+		Locale:    "en-US",
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Name:      client.Name{DisplayName: "Maya Chen"},
+		Emails:    []client.Email{{Value: "maya@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-12",
+		UserID: "user-12",
+		Status: "ACTIVE",
+	}
+	workLocation := &client.WorkLocation{
+		ID:   "loc-remote",
+		Name: "Remote",
+	}
+
+	r, err := userResource(user, worker, workLocation)
+	assert.NoError(t, err)
+	assert.Equal(t, "Maya Chen", r.DisplayName)
 }
 
 func TestUserResource_InvalidCreatedAt(t *testing.T) {
@@ -291,7 +372,7 @@ func TestUserResource_InvalidCreatedAt(t *testing.T) {
 		Name:      client.Name{DisplayName: "Frank"},
 	}
 
-	_, err := userResource(user, nil)
+	_, err := userResource(user, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse created_at")
 }

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/conductorone/baton-rippling/pkg/client"
+	"github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -222,18 +223,41 @@ func TestUserResource_ProfileNameAndAddressFields(t *testing.T) {
 	}
 
 	r, err := userResource(user, worker, nil)
-	assert.NoError(t, err)
-
-	// Extract profile from annotations
-	userTrait := r.GetAnnotations()
-	assert.NotNil(t, userTrait)
-
-	// Verify the resource was created with the right display name
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, "Grace Hopper", r.DisplayName)
-
-	// Verify the resource was created successfully (profile is in annotations,
-	// we trust the implementation above sets them correctly based on the code).
 	assert.Equal(t, "user-7", r.Id.Resource)
+
+	// Extract profile and verify address deduplication
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	profileFields := trait.GetProfile().GetFields()
+	addressesVal := profileFields["addresses"].GetStructValue()
+	if !assert.NotNil(t, addressesVal) {
+		return
+	}
+
+	// First WORK address should be kept
+	workAddr := addressesVal.GetFields()["work"].GetStructValue()
+	if assert.NotNil(t, workAddr, "expected work address in profile") {
+		assert.Equal(t, "Arlington", workAddr.GetFields()["locality"].GetStringValue())
+		assert.Equal(t, "VA", workAddr.GetFields()["region"].GetStringValue())
+		assert.Equal(t, "US", workAddr.GetFields()["country"].GetStringValue())
+
+		// Second WORK address (Washington, DC) should NOT appear — first one wins
+		assert.NotEqual(t, "Washington", workAddr.GetFields()["locality"].GetStringValue())
+		assert.NotEqual(t, "DC", workAddr.GetFields()["region"].GetStringValue())
+	}
+
+	// HOME address should also be present
+	homeAddr := addressesVal.GetFields()["home"].GetStructValue()
+	if assert.NotNil(t, homeAddr, "expected home address in profile") {
+		assert.Equal(t, "New York", homeAddr.GetFields()["locality"].GetStringValue())
+	}
 }
 
 func TestUserResource_AddressWithEmptyType(t *testing.T) {
@@ -313,8 +337,28 @@ func TestUserResource_WithWorkLocation(t *testing.T) {
 	}
 
 	r, err := userResource(user, worker, workLocation)
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, "Kate Walsh", r.DisplayName)
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fields := trait.GetProfile().GetFields()
+
+	assert.Equal(t, "New York Office", fields["work_location_name"].GetStringValue())
+
+	addrVal := fields["work_location_address"].GetStructValue()
+	if assert.NotNil(t, addrVal, "expected work_location_address in profile") {
+		addrFields := addrVal.GetFields()
+		assert.Equal(t, "350 Fifth Ave", addrFields["street_address"].GetStringValue())
+		assert.Equal(t, "New York", addrFields["locality"].GetStringValue())
+		assert.Equal(t, "NY", addrFields["region"].GetStringValue())
+		assert.Equal(t, "10118", addrFields["postal_code"].GetStringValue())
+		assert.Equal(t, "US", addrFields["country"].GetStringValue())
+	}
 }
 
 func TestUserResource_NilWorkLocation(t *testing.T) {
@@ -359,8 +403,19 @@ func TestUserResource_WorkLocationNameOnly(t *testing.T) {
 	}
 
 	r, err := userResource(user, worker, workLocation)
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, "Maya Chen", r.DisplayName)
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fields := trait.GetProfile().GetFields()
+
+	assert.Equal(t, "Remote", fields["work_location_name"].GetStringValue())
+	assert.Nil(t, fields["work_location_address"], "expected no work_location_address when address is nil")
 }
 
 func TestUserResource_InvalidCreatedAt(t *testing.T) {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -229,38 +229,27 @@ func TestUserResource_ProfileNameAndAddressFields(t *testing.T) {
 	assert.Equal(t, "Grace Hopper", r.DisplayName)
 	assert.Equal(t, "user-7", r.Id.Resource)
 
-	// Extract profile and verify address deduplication
+	// Extract profile and verify only the first WORK address is used
 	trait, err := resource.GetUserTrait(r)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	profileFields := trait.GetProfile().GetFields()
-	addressesVal := profileFields["addresses"].GetStructValue()
-	if !assert.NotNil(t, addressesVal) {
-		return
-	}
-
-	// First WORK address should be kept
-	workAddr := addressesVal.GetFields()["work"].GetStructValue()
-	if assert.NotNil(t, workAddr, "expected work address in profile") {
-		assert.Equal(t, "Arlington", workAddr.GetFields()["locality"].GetStringValue())
-		assert.Equal(t, "VA", workAddr.GetFields()["region"].GetStringValue())
-		assert.Equal(t, "US", workAddr.GetFields()["country"].GetStringValue())
+	addrVal := profileFields["address"].GetStructValue()
+	if assert.NotNil(t, addrVal, "expected address in profile") {
+		// First WORK address should be kept
+		assert.Equal(t, "Arlington", addrVal.GetFields()["locality"].GetStringValue())
+		assert.Equal(t, "VA", addrVal.GetFields()["region"].GetStringValue())
+		assert.Equal(t, "US", addrVal.GetFields()["country"].GetStringValue())
 
 		// Second WORK address (Washington, DC) should NOT appear — first one wins
-		assert.NotEqual(t, "Washington", workAddr.GetFields()["locality"].GetStringValue())
-		assert.NotEqual(t, "DC", workAddr.GetFields()["region"].GetStringValue())
-	}
-
-	// HOME address should also be present
-	homeAddr := addressesVal.GetFields()["home"].GetStructValue()
-	if assert.NotNil(t, homeAddr, "expected home address in profile") {
-		assert.Equal(t, "New York", homeAddr.GetFields()["locality"].GetStringValue())
+		assert.NotEqual(t, "Washington", addrVal.GetFields()["locality"].GetStringValue())
+		assert.NotEqual(t, "DC", addrVal.GetFields()["region"].GetStringValue())
 	}
 }
 
-func TestUserResource_AddressWithEmptyType(t *testing.T) {
+func TestUserResource_AddressWithNonWorkType(t *testing.T) {
 	user := client.User{
 		ID:        "user-8",
 		Username:  "hank",
@@ -271,7 +260,7 @@ func TestUserResource_AddressWithEmptyType(t *testing.T) {
 		Emails:    []client.Email{{Value: "hank@example.com"}},
 		Addresses: []client.Address{
 			{
-				Type:     "",
+				Type:     "HOME",
 				Locality: "Arlen",
 				Region:   "TX",
 				Country:  "US",
@@ -280,8 +269,17 @@ func TestUserResource_AddressWithEmptyType(t *testing.T) {
 	}
 
 	r, err := userResource(user, nil, nil)
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	assert.Equal(t, "Hank Hill", r.DisplayName)
+
+	// Non-WORK addresses should not produce an address field
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Nil(t, trait.GetProfile().GetFields()["address"], "expected no address for non-WORK type")
 }
 
 func TestUserResource_AddressAllFieldsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

- Enriches user profiles with worker attributes: title, status, start/end date, work email, manager info, department, level, and employment type fields (`employment_type`, `employment_name`, `employment_label`)
- Enriches user profiles with name fields (given, family, middle, formatted, preferred given/family)
- Adds work address from SCIM user data, extracting `locality`, `region`, `country` as top-level profile fields
- Adds `--expand-work-locations` config toggle to fetch work locations via `GET /work-locations` and enrich user profiles with `work_location_name` and `work_location_address` (work location address takes precedence over user work address for top-level locality/region/country)
- Implements three-phase `List()`: work locations → workers → users, with locations and workers cached in the session store
- Adds configurable `--base-url` flag for mock server testing
- Moves `display_name` from `Name` to `User`/`WorkerUser` structs to match Rippling API docs
- Adds `WithUserLogin` trait to user resources
- Refactors `ListWorkers` to use shared `doGet` helper

## Test plan

- [x] `go build ./cmd/baton-rippling` passes
- [x] `go test ./...` passes — unit tests cover profile field extraction, address handling, work location enrichment, nil/empty edge cases
- [x] Manual: run with `--expand-work-locations`, verify `work_location_name` and `work_location_address` in user profiles
- [x] Manual: run without flag, verify no extra API calls and unchanged behavior
- [x] Manual: verify `employment_type`, `employment_name`, `employment_label` emit distinct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)