### PR TITLE
[CXP-419] Sync custom fields from Rippling Workers endpoint

### DIFF
--- a/cmd/baton-rippling/main.go
+++ b/cmd/baton-rippling/main.go
@@ -57,7 +57,8 @@ func getConnector(ctx context.Context, config *cfg.Rippling, runTimeOpts cli.Run
 		Department:     config.ExpandDepartment,
 		EmploymentType: config.ExpandEmploymentType,
 		Level:          config.ExpandLevel,
-	}, config.ExpandWorkLocations)
+		CustomFields:   len(config.CustomFields) > 0,
+	}, config.ExpandWorkLocations, config.CustomFields)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/config_schema.json
+++ b/config_schema.json
@@ -127,6 +127,12 @@
       "displayName": "Expand work locations",
       "description": "Include work location name and address in user profiles. Requires the work-locations.read scope.",
       "boolField": {}
+    },
+    {
+      "name": "custom-fields",
+      "displayName": "Custom fields",
+      "description": "List of custom field names to sync from the Rippling Workers endpoint. Only fields with names matching this list (case-insensitive) will be included in user profiles.",
+      "stringSliceField": {}
     }
   ],
   "displayName": "Rippling",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -82,6 +82,15 @@ Find the **Settings** area of the page and click **Edit**.
 Enter your token into the **API token** field. 
 </Step>
 <Step>
+Optionally, configure additional sync settings:
+
+   * **Expand department**: Include department data in worker sync. Requires the `departments.read` scope.
+   * **Expand employment type**: Include employment type data. Requires the `employment-types.read` scope.
+   * **Expand level**: Include level data. Requires the `levels.read` scope.
+   * **Expand work locations**: Include work location name and address. Requires the `work-locations.read` scope.
+   * **Custom fields**: A list of custom field names to sync from the Rippling Workers endpoint. Only fields with names matching this list (case-insensitive) will be included in user profiles. For example, to sync scrum team data, enter `Scrum Teams` and `Scrum Team Code`. Requires the `custom_fields.read` scope.
+</Step>
+<Step>
 Click **Save**.
 </Step>
 <Step>
@@ -154,6 +163,9 @@ stringData:
   
   # Rippling credentials
   BATON_API_TOKEN: <Rippling API token>
+  
+  # Optional: sync specific custom fields from worker profiles
+  # BATON_CUSTOM_FIELDS: "Scrum Teams,Scrum Team Code"
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -14,6 +14,7 @@ type ExpandOptions struct {
 	Department     bool
 	EmploymentType bool
 	Level          bool
+	CustomFields   bool
 }
 
 type Client struct {
@@ -57,6 +58,9 @@ func (c *Client) buildExpandParam() string {
 	}
 	if c.expandOptions.Level {
 		fields = append(fields, "level")
+	}
+	if c.expandOptions.CustomFields {
+		fields = append(fields, "custom_fields")
 	}
 	return strings.Join(fields, ",")
 }

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -255,6 +255,13 @@ type BusinessPartner struct {
 	ClientGroupMemberCount int                   `json:"client_group_member_count,omitempty"`
 }
 
+type CustomField struct {
+	ID    *string `json:"id"`
+	Name  string  `json:"name"`
+	Type  string  `json:"type"`
+	Value string  `json:"value"`
+}
+
 type Worker struct {
 	ID                 string              `json:"id"`
 	CreatedAt          string              `json:"created_at"`
@@ -292,7 +299,7 @@ type Worker struct {
 	LevelID            string              `json:"level_id,omitempty"`
 	Level              *Level              `json:"level,omitempty"`
 	TerminationDetails *TerminationDetails `json:"termination_details,omitempty"`
-	CustomFields       []interface{}       `json:"custom_fields,omitempty"`
+	CustomFields       []CustomField       `json:"custom_fields,omitempty"`
 	CountryFields      *CountryFields      `json:"country_fields,omitempty"`
 	BusinessPartnersID []string            `json:"business_partners_id,omitempty"`
 	BusinessPartners   []BusinessPartner   `json:"business_partners,omitempty"`

--- a/pkg/client/models.go
+++ b/pkg/client/models.go
@@ -259,7 +259,7 @@ type CustomField struct {
 	ID    *string `json:"id"`
 	Name  string  `json:"name"`
 	Type  string  `json:"type"`
-	Value string  `json:"value"`
+	Value any     `json:"value"`
 }
 
 type Worker struct {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,6 +10,7 @@ type Rippling struct {
 	ExpandEmploymentType bool `mapstructure:"expand-employment-type"`
 	ExpandLevel bool `mapstructure:"expand-level"`
 	ExpandWorkLocations bool `mapstructure:"expand-work-locations"`
+	CustomFields []string `mapstructure:"custom-fields"`
 }
 
 func (c *Rippling) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,10 @@ var (
 		field.WithDisplayName("Expand work locations"),
 		field.WithDescription("Include work location name and address in user profiles. Requires the work-locations.read scope."),
 	)
+	CustomFields = field.StringSliceField("custom-fields",
+		field.WithDisplayName("Custom fields"),
+		field.WithDescription("List of custom field names to sync from the Rippling Workers endpoint. Only fields with names matching this list (case-insensitive) will be included in user profiles."),
+	)
 	ConfigurationFields = []field.SchemaField{
 		ApiToken,
 		BaseURL,
@@ -43,6 +47,7 @@ var (
 		ExpandEmploymentType,
 		ExpandLevel,
 		ExpandWorkLocations,
+		CustomFields,
 	}
 
 	// FieldRelationships defines relationships between the ConfigurationFields that can be automatically validated.

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -12,14 +12,15 @@ import (
 )
 
 type Connector struct {
-	client               *client.Client
-	expandWorkLocations  bool
+	client              *client.Client
+	expandWorkLocations bool
+	customFieldNames    []string
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client, d.expandWorkLocations),
+		newUserBuilder(d.client, d.expandWorkLocations, d.customFieldNames),
 		newTeamBuilder(d.client),
 	}
 }
@@ -45,7 +46,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiToken string, baseURL string, expandOpts client.ExpandOptions, expandWorkLocations bool) (*Connector, error) {
+func New(ctx context.Context, apiToken string, baseURL string, expandOpts client.ExpandOptions, expandWorkLocations bool, customFieldNames []string) (*Connector, error) {
 	c, err := client.New(ctx, apiToken, baseURL, expandOpts)
 	if err != nil {
 		return nil, fmt.Errorf("baton-rippling: failed to create client: %w", err)
@@ -53,5 +54,6 @@ func New(ctx context.Context, apiToken string, baseURL string, expandOpts client
 	return &Connector{
 		client:              c,
 		expandWorkLocations: expandWorkLocations,
+		customFieldNames:    customFieldNames,
 	}, nil
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -164,14 +164,19 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 				allowed[strings.ToLower(name)] = true
 			}
 			for _, cf := range worker.CustomFields {
-				if cf.Name == "" || cf.Value == "" {
+				name := strings.TrimSpace(cf.Name)
+				if name == "" || cf.Value == nil {
 					continue
 				}
-				if !allowed[strings.ToLower(cf.Name)] {
+				if !allowed[strings.ToLower(name)] {
 					continue
 				}
-				key := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(cf.Name), " ", "_"))
-				profile[key] = cf.Value
+				key := strings.ToLower(strings.ReplaceAll(name, " ", "_"))
+				strVal := fmt.Sprintf("%v", cf.Value)
+				if strVal == "" {
+					continue
+				}
+				profile[key] = strVal
 			}
 		}
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -41,7 +41,7 @@ func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return userResourceType
 }
 
-func userResource(user client.User, worker *client.Worker, workLocation *client.WorkLocation) (*v2.Resource, error) {
+func userResource(user client.User, worker *client.Worker, workLocation *client.WorkLocation, customFieldNames []string) (*v2.Resource, error) {
 	profile := map[string]any{
 		"username": user.Username,
 		"active":   user.Active,
@@ -155,6 +155,24 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		// Location information
 		if worker.Location != nil && worker.Location.WorkLocationID != "" {
 			profile["work_location_id"] = worker.Location.WorkLocationID
+		}
+
+		// Custom fields — only include fields whose names match the configured list.
+		if len(customFieldNames) > 0 {
+			allowed := make(map[string]bool, len(customFieldNames))
+			for _, name := range customFieldNames {
+				allowed[strings.ToLower(name)] = true
+			}
+			for _, cf := range worker.CustomFields {
+				if cf.Name == "" || cf.Value == "" {
+					continue
+				}
+				if !allowed[strings.ToLower(cf.Name)] {
+					continue
+				}
+				key := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(cf.Name), " ", "_"))
+				profile[key] = cf.Value
+			}
 		}
 	}
 
@@ -356,7 +374,7 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 			}
 		}
 
-		r, err := userResource(user, workerPtr, workLocationPtr)
+		r, err := userResource(user, workerPtr, workLocationPtr, o.customFieldNames)
 		if err != nil {
 			return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: failed to convert user %s to resource: %w", user.ID, err)
 		}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -34,6 +34,7 @@ const (
 type userBuilder struct {
 	client              *client.Client
 	expandWorkLocations bool
+	customFieldNames    []string
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -446,9 +447,10 @@ func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.
 	return rv, nil, nil
 }
 
-func newUserBuilder(client *client.Client, expandWorkLocations bool) *userBuilder {
+func newUserBuilder(client *client.Client, expandWorkLocations bool, customFieldNames []string) *userBuilder {
 	return &userBuilder{
 		client:              client,
 		expandWorkLocations: expandWorkLocations,
+		customFieldNames:    customFieldNames,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -172,7 +173,17 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 					continue
 				}
 				key := strings.ToLower(strings.ReplaceAll(name, " ", "_"))
-				strVal := fmt.Sprintf("%v", cf.Value)
+				if _, exists := profile[key]; exists {
+					continue // don't overwrite built-in profile fields
+				}
+				var strVal string
+				switch v := cf.Value.(type) {
+				case string:
+					strVal = v
+				default:
+					b, _ := json.Marshal(v)
+					strVal = string(b)
+				}
 				if strVal == "" {
 					continue
 				}

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -532,3 +532,38 @@ func TestUserResource_NoCustomFieldsConfig(t *testing.T) {
 
 	assert.Nil(t, fields["scrum_teams"], "custom field should not appear when config is empty")
 }
+
+func TestUserResource_CustomFieldsDoNotOverwriteBuiltIn(t *testing.T) {
+	user := client.User{
+		ID:          "user-cf-4",
+		Username:    "dave",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Dave Kim",
+		Emails:      []client.Email{{Value: "dave@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-cf-4",
+		UserID: "user-cf-4",
+		Status: "ACTIVE",
+		Title:  "Senior Engineer",
+		CustomFields: []client.CustomField{
+			{Name: "Title", Type: "text", Value: "Should Not Overwrite"},
+		},
+	}
+
+	r, err := userResource(user, worker, nil, []string{"Title"})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fields := trait.GetProfile().GetFields()
+
+	// Built-in "title" from worker.Title should be preserved, not overwritten
+	assert.Equal(t, "Senior Engineer", fields["title"].GetStringValue())
+}

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -26,7 +26,7 @@ func TestUserResource_NoWorker(t *testing.T) {
 		Emails: []client.Email{{Value: "alice@example.com"}},
 	}
 
-	r, err := userResource(user, nil, nil)
+	r, err := userResource(user, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Alice Smith", r.DisplayName)
 	assert.Equal(t, "user-1", r.Id.Resource)
@@ -94,7 +94,7 @@ func TestUserResource_WithFullWorker(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, worker, nil)
+	r, err := userResource(user, worker, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Bob Jones", r.DisplayName)
 	assert.Equal(t, "user-2", r.Id.Resource)
@@ -122,7 +122,7 @@ func TestUserResource_WorkerWithNilNestedStructs(t *testing.T) {
 		Location:       nil,
 	}
 
-	r, err := userResource(user, worker, nil)
+	r, err := userResource(user, worker, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Carol Lee", r.DisplayName)
 }
@@ -152,7 +152,7 @@ func TestUserResource_WorkerEmptyStringsNotIncluded(t *testing.T) {
 		Location:   &client.Location{WorkLocationID: ""},
 	}
 
-	r, err := userResource(user, worker, nil)
+	r, err := userResource(user, worker, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Dave Kim", r.DisplayName)
 }
@@ -168,7 +168,7 @@ func TestUserResource_NoEmails(t *testing.T) {
 		Emails:    nil,
 	}
 
-	r, err := userResource(user, nil, nil)
+	r, err := userResource(user, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Eve Wu", r.DisplayName)
 }
@@ -222,7 +222,7 @@ func TestUserResource_ProfileNameAndAddressFields(t *testing.T) {
 		Department:   &client.Department{Name: "R&D"},
 	}
 
-	r, err := userResource(user, worker, nil)
+	r, err := userResource(user, worker, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -268,7 +268,7 @@ func TestUserResource_AddressWithNonWorkType(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, nil, nil)
+	r, err := userResource(user, nil, nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -299,7 +299,7 @@ func TestUserResource_AddressAllFieldsEmpty(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, nil, nil)
+	r, err := userResource(user, nil, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Irene Adler", r.DisplayName)
 }
@@ -334,7 +334,7 @@ func TestUserResource_WithWorkLocation(t *testing.T) {
 		},
 	}
 
-	r, err := userResource(user, worker, workLocation)
+	r, err := userResource(user, worker, workLocation, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -375,7 +375,7 @@ func TestUserResource_NilWorkLocation(t *testing.T) {
 		Status: "ACTIVE",
 	}
 
-	r, err := userResource(user, worker, nil)
+	r, err := userResource(user, worker, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "Leo Park", r.DisplayName)
 }
@@ -400,7 +400,7 @@ func TestUserResource_WorkLocationNameOnly(t *testing.T) {
 		Name: "Remote",
 	}
 
-	r, err := userResource(user, worker, workLocation)
+	r, err := userResource(user, worker, workLocation, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -425,7 +425,110 @@ func TestUserResource_InvalidCreatedAt(t *testing.T) {
 		DisplayName: "Frank",
 	}
 
-	_, err := userResource(user, nil, nil)
+	_, err := userResource(user, nil, nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse created_at")
+}
+
+func TestUserResource_CustomFieldsAddedToProfile(t *testing.T) {
+	user := client.User{
+		ID:          "user-cf-1",
+		Username:    "alice",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Alice Smith",
+		Emails:      []client.Email{{Value: "alice@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-cf-1",
+		UserID: "user-cf-1",
+		Status: "ACTIVE",
+		CustomFields: []client.CustomField{
+			{Name: "Scrum Teams", Type: "text", Value: "Digital Onboarding"},
+			{Name: "Scrum Team Code", Type: "text", Value: "DOB"},
+			{Name: "Other Field", Type: "text", Value: "should be excluded"},
+		},
+	}
+
+	r, err := userResource(user, worker, nil, []string{"Scrum Teams", "Scrum Team Code"})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fields := trait.GetProfile().GetFields()
+
+	assert.Equal(t, "Digital Onboarding", fields["scrum_teams"].GetStringValue())
+	assert.Equal(t, "DOB", fields["scrum_team_code"].GetStringValue())
+	assert.Nil(t, fields["other_field"], "non-configured custom field should not appear")
+}
+
+func TestUserResource_CustomFieldsCaseInsensitive(t *testing.T) {
+	user := client.User{
+		ID:          "user-cf-2",
+		Username:    "bob",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Bob Jones",
+		Emails:      []client.Email{{Value: "bob@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-cf-2",
+		UserID: "user-cf-2",
+		Status: "ACTIVE",
+		CustomFields: []client.CustomField{
+			{Name: "SCRUM TEAMS", Type: "text", Value: "Platform"},
+		},
+	}
+
+	r, err := userResource(user, worker, nil, []string{"scrum teams"})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fields := trait.GetProfile().GetFields()
+
+	assert.Equal(t, "Platform", fields["scrum_teams"].GetStringValue())
+}
+
+func TestUserResource_NoCustomFieldsConfig(t *testing.T) {
+	user := client.User{
+		ID:          "user-cf-3",
+		Username:    "carol",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Carol Lee",
+		Emails:      []client.Email{{Value: "carol@example.com"}},
+	}
+	worker := &client.Worker{
+		ID:     "worker-cf-3",
+		UserID: "user-cf-3",
+		Status: "ACTIVE",
+		CustomFields: []client.CustomField{
+			{Name: "Scrum Teams", Type: "text", Value: "Digital Onboarding"},
+		},
+	}
+
+	r, err := userResource(user, worker, nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+	fields := trait.GetProfile().GetFields()
+
+	assert.Nil(t, fields["scrum_teams"], "custom field should not appear when config is empty")
 }


### PR DESCRIPTION
## Summary

- Add `custom-fields` config option (string slice) allowing customers to opt-in to syncing specific custom field values from the Rippling Workers API as user profile attributes
- When configured, adds `custom_fields` to the workers API `expand` parameter
- Matching fields are added to the user profile with normalized snake_case keys (e.g., `"Scrum Teams"` → `scrum_teams`) using case-insensitive name matching
- Typed `CustomField` model replaces `[]interface{}` with `any`-typed `Value` to safely handle non-string API responses

## Context

Advisor360 needs Scrum Team data (team name and team code) available as user attributes in ConductorOne for access governance workflows. This data is available via Rippling's Workers endpoint `custom_fields`.

## Test plan

- [x] Verify only configured custom field names are synced to user profile
- [x] Verify case-insensitive matching (config `"scrum teams"` matches API `"SCRUM TEAMS"`)
- [x] Verify empty/nil config syncs no custom fields (existing customers unaffected)
- [x] Verify all 15 existing + new tests pass
- [x] Verify clean build
- [ ] Integration test with Rippling sandbox using `--custom-fields="Scrum Teams,Scrum Team Code"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)