### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Rippling connector
 og:title: Set up a Rippling connector - C1 docs
-og:description: Integrate your Rippling (Akamai) instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Rippling. Integrate your Rippling (Akamai) instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Rippling. Integrate your Rippling instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Rippling. Integrate your Rippling instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Rippling
 ---
 
@@ -36,7 +36,7 @@ Configure the scopes for the API token, giving it the permission to view all Rip
 Create the token, then carefully copy and save the token value. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions.  
+**Done.** Next, move on to the connector configuration instructions.  
 
 ## Configure the Rippling connector
 
@@ -97,7 +97,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Rippling connector is now pulling access data into C1.
+**Done.** Your Rippling connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Rippling connector, hosted and run in your own environment.**
@@ -213,7 +213,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Rippling connector to. Rippling data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Rippling connector is now pulling access data into C1.
+**Done.** Your Rippling connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines