### PR TITLE
[CXP-478] Add work email as login alias on directory users

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -246,11 +246,19 @@ func userResource(user client.User, worker *client.Worker, workLocation *client.
 		}
 	}
 
+	// Rippling's user.Username is not guaranteed to be the work email — it can
+	// be a personal/pre-boarding address. Emit the work email as a login alias
+	// so SSO lookups and cross-connector AppUser matching resolve to this user.
+	var aliases []string
+	if workEmail := resolveWorkEmail(user, worker); workEmail != "" && !strings.EqualFold(workEmail, user.Username) {
+		aliases = append(aliases, workEmail)
+	}
+
 	userOpts := []resource.UserTraitOption{
 		resource.WithUserProfile(profile),
 		resource.WithCreatedAt(createdAt),
 		resource.WithStatus(userStatus),
-		resource.WithUserLogin(user.Username),
+		resource.WithUserLogin(user.Username, aliases...),
 	}
 
 	email := getWorkEmail(user.Emails)
@@ -424,6 +432,18 @@ func (o *userBuilder) List(ctx context.Context, _ *v2.ResourceId, opts resource.
 		// Phase 3: page through users, looking up cached workers and locations per-user.
 		return o.listUserPage(ctx, strings.TrimPrefix(token, usersPagePrefix), opts.Session)
 	}
+}
+
+// resolveWorkEmail returns the user's work email for use as a login alias:
+// worker.WorkEmail takes precedence, then a WORK-typed entry in user.Emails.
+func resolveWorkEmail(user client.User, worker *client.Worker) string {
+	if worker != nil && worker.WorkEmail != "" {
+		return worker.WorkEmail
+	}
+	if e := getWorkEmail(user.Emails); e != nil && e.Value != "" && strings.EqualFold(e.Type, workType) {
+		return e.Value
+	}
+	return ""
 }
 
 func getWorkEmail(emails []client.Email) *client.Email {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -567,3 +567,121 @@ func TestUserResource_CustomFieldsDoNotOverwriteBuiltIn(t *testing.T) {
 	// Built-in "title" from worker.Title should be preserved, not overwritten
 	assert.Equal(t, "Senior Engineer", fields["title"].GetStringValue())
 }
+
+func TestUserResource_LoginAlias_FromWorkerWorkEmail(t *testing.T) {
+	user := client.User{
+		ID:          "user-alias-1",
+		Username:    "alice.personal@gmail.com",
+		Active:      true,
+		Locale:      "en-US",
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Alice Smith",
+	}
+	worker := &client.Worker{
+		ID:        "worker-alias-1",
+		UserID:    "user-alias-1",
+		Status:    "ACTIVE",
+		WorkEmail: "alice@company.com",
+	}
+
+	r, err := userResource(user, worker, nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "alice.personal@gmail.com", trait.GetLogin(), "primary login should remain user.Username")
+	assert.Equal(t, []string{"alice@company.com"}, trait.GetLoginAliases(), "worker.WorkEmail should be a login alias")
+}
+
+func TestUserResource_LoginAlias_FallbackToWorkTypeEmail(t *testing.T) {
+	user := client.User{
+		ID:          "user-alias-2",
+		Username:    "bob.personal@gmail.com",
+		Active:      true,
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Bob Jones",
+		Emails: []client.Email{
+			{Value: "bob.personal@gmail.com", Type: "HOME"},
+			{Value: "bob@company.com", Type: "WORK"},
+		},
+	}
+	// Worker present but WorkEmail empty — the WORK-typed email on user should be used as the alias.
+	worker := &client.Worker{
+		ID:     "worker-alias-2",
+		UserID: "user-alias-2",
+		Status: "ACTIVE",
+	}
+
+	r, err := userResource(user, worker, nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "bob.personal@gmail.com", trait.GetLogin())
+	assert.Equal(t, []string{"bob@company.com"}, trait.GetLoginAliases())
+}
+
+func TestUserResource_LoginAlias_NoAliasWhenWorkEmailMatchesUsername(t *testing.T) {
+	user := client.User{
+		ID:          "user-alias-3",
+		Username:    "carol@company.com",
+		Active:      true,
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Carol Lee",
+	}
+	worker := &client.Worker{
+		ID:        "worker-alias-3",
+		UserID:    "user-alias-3",
+		Status:    "ACTIVE",
+		WorkEmail: "CAROL@company.com",
+	}
+
+	r, err := userResource(user, worker, nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "carol@company.com", trait.GetLogin())
+	assert.Empty(t, trait.GetLoginAliases(), "no alias expected when work email matches username (case-insensitive)")
+}
+
+func TestUserResource_LoginAlias_NoAliasWhenNoWorkEmailAvailable(t *testing.T) {
+	user := client.User{
+		ID:          "user-alias-4",
+		Username:    "dave",
+		Active:      true,
+		CreatedAt:   "2024-01-01T00:00:00Z",
+		DisplayName: "Dave Kim",
+		Emails: []client.Email{
+			{Value: "dave@home.example", Type: "HOME"},
+		},
+	}
+
+	r, err := userResource(user, nil, nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	trait, err := resource.GetUserTrait(r)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "dave", trait.GetLogin())
+	assert.Empty(t, trait.GetLoginAliases())
+}


### PR DESCRIPTION
## Summary

Emit the Rippling worker's `workEmail` as a **login alias** on the C1 directory user instead of replacing the primary `Username`. This satisfies the three CXP-478 requirements — SSO assertions matching, cross-connector user matching, and grant/entitlement reconciliation — without re-keying existing users.

### Why an alias, not a replacement

Rippling's `user.username` is Rippling's internal login identifier and can legitimately be a personal/pre-boarding address. The original CXP-478 proposal was to replace the C1 primary `Username` with `workEmail`. That works, but it also **deletes** the existing `UserUsernameBinding` keyed on `user.username` — which severs any other connector's AppUser that was previously matching to this user via that value.

C1 indexes users by `Username` **and** every entry in `Usernames` (which includes `LoginAliases`) in two places:

- `AppUserManager.AppendUser` → in-memory `userUsernameToLower` index used by `mapIdentities` during uplift.
- `findUserUsernameBindings` → persistent `UserUsernameBinding` GSI used for username lookups (including SSO).

Adding the work email as an alias expands those indexes **additively**:

- SSO assertions keyed on the work email resolve to the user via the new binding.
- Other connectors whose AppUsers have a `workEmail` primary match via `email->username` / `username->username` in `mapIdentities`.
- Grant/entitlement reconciliation follows from the matching.
- No existing bindings are deleted, so no AppUsers get orphaned mid-sync.

### Changes

- `userResource` now computes a work email (prefer `worker.WorkEmail`, fall back to a `WORK`-typed entry in `user.Emails`) and passes it as an alias to `WithUserLogin` when it's non-empty and differs from `user.Username` (case-insensitive).
- Primary login (`user.Username`), primary email, and all existing profile fields are unchanged.
- `rippling_username` profile key is **not** introduced — the primary login still carries the original value.

### Trade-off

Because the primary `Username` is unchanged, the directory user's displayed username in the C1 UI continues to show whatever Rippling returns in `user.username` (which may be a personal email). This PR deliberately does not address that cosmetic concern — the goal here is to fix the matching/SSO mechanics with the minimum blast radius. A follow-up can change the displayed primary separately if needed.

### Test plan

- [x] `TestUserResource_LoginAlias_FromWorkerWorkEmail` — alias emitted from `worker.WorkEmail`
- [x] `TestUserResource_LoginAlias_FallbackToWorkTypeEmail` — alias falls back to `WORK`-typed `user.Emails` entry when `worker.WorkEmail` is empty
- [x] `TestUserResource_LoginAlias_NoAliasWhenWorkEmailMatchesUsername` — no alias added when the work email equals the primary login (case-insensitive)
- [x] `TestUserResource_LoginAlias_NoAliasWhenNoWorkEmailAvailable` — no alias added when neither `worker.WorkEmail` nor a `WORK`-typed email is present
- [x] All existing `userResource` tests pass unchanged (no primary-username behavior was modified)
- [x] `go build ./...` succeeds
- [x] `golangci-lint run ./pkg/connector/...` clean