### PR TITLE
fix(users): recover missing worker via per-user GET on cache miss

### DIFF
--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -60,9 +60,6 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 	return &workers, rl, nil
 }
 
-// GetWorkersByUserID fetches workers via filter=user_id+eq+'<id>'. Used to
-// recover from /workers cursor-walk misses. Returns a slice because Rippling
-// permits multiple Worker records per user_id (re-hire case).
 func (c *Client) GetWorkersByUserID(ctx context.Context, userID string) (*WorkersResponse, *v2.RateLimitDescription, error) {
 	u, _ := url.Parse(c.workersURL())
 	q := u.Query()

--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -60,6 +60,26 @@ func (c *Client) ListWorkers(ctx context.Context, nextLink string) (*WorkersResp
 	return &workers, rl, nil
 }
 
+// GetWorkersByUserID fetches workers via filter=user_id+eq+'<id>'. Used to
+// recover from /workers cursor-walk misses. Returns a slice because Rippling
+// permits multiple Worker records per user_id (re-hire case).
+func (c *Client) GetWorkersByUserID(ctx context.Context, userID string) (*WorkersResponse, *v2.RateLimitDescription, error) {
+	u, _ := url.Parse(c.workersURL())
+	q := u.Query()
+	q.Set("filter", fmt.Sprintf("user_id eq '%s'", userID))
+	if expand := c.buildExpandParam(); expand != "" {
+		q.Set("expand", expand)
+	}
+	u.RawQuery = q.Encode()
+
+	var workers WorkersResponse
+	rl, err := c.doGet(ctx, u.String(), "", &workers)
+	if err != nil {
+		return nil, rl, fmt.Errorf("failed to fetch worker by user_id %s: %w", userID, err)
+	}
+	return &workers, rl, nil
+}
+
 func (c *Client) ListTeams(ctx context.Context, nextLink string) (*TeamsResponse, *v2.RateLimitDescription, error) {
 	var teams TeamsResponse
 	rl, err := c.doGet(ctx, c.teamsURL(), nextLink, &teams)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -390,7 +390,8 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 		if worker, found := workers[user.ID]; found {
 			workerPtr = &worker
 		} else {
-			recovered, err := o.fetchWorker(ctx, user.ID)
+			recovered, rl, err := o.fetchWorker(ctx, user.ID)
+			annos = *annos.WithRateLimiting(rl)
 			if err != nil {
 				return nil, &resource.SyncOpResults{Annotations: annos}, err
 			}
@@ -475,25 +476,26 @@ func (o *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ resource
 // Grants returns team membership grants for this user by looking up the user's
 // worker record from the session store and creating a grant for each team.
 func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	var annos annotations.Annotations
 	worker, found, err := session.GetJSON[client.Worker](ctx, opts.Session, r.Id.Resource, sessions.WithPrefix(workersSessionPrefix))
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-rippling: failed to get worker for user %s from session store: %w", r.Id.Resource, err)
 	}
 	if !found {
-		recovered, err := o.fetchWorker(ctx, r.Id.Resource)
+		recovered, rl, err := o.fetchWorker(ctx, r.Id.Resource)
+		annos = *annos.WithRateLimiting(rl)
 		if err != nil {
-			return nil, nil, err
+			return nil, &resource.SyncOpResults{Annotations: annos}, err
 		}
 		if recovered == nil {
 			ctxzap.Extract(ctx).Debug("no worker exists for user, skipping team grants", zap.String("user_id", r.Id.Resource))
-			return nil, nil, nil
+			return nil, &resource.SyncOpResults{Annotations: annos}, nil
 		}
 		worker = *recovered
 	}
 	if worker.Status == "TERMINATED" {
-		l := ctxzap.Extract(ctx)
-		l.Debug("worker is terminated, skipping team grants", zap.String("user_id", r.Id.Resource))
-		return nil, nil, nil
+		ctxzap.Extract(ctx).Debug("worker is terminated, skipping team grants", zap.String("user_id", r.Id.Resource))
+		return nil, &resource.SyncOpResults{Annotations: annos}, nil
 	}
 
 	rv := make([]*v2.Grant, 0, len(worker.TeamsID))
@@ -510,24 +512,28 @@ func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.
 		))
 	}
 
-	return rv, nil, nil
+	return rv, &resource.SyncOpResults{Annotations: annos}, nil
 }
 
-// fetchWorker fetches a worker by user_id via the /workers filter API. Used
-// to recover from /workers cursor-walk misses where a user appears in /users
-// but the bulk pagination did not return their worker. A nil result means
-// Rippling has no worker for this user (legitimate admin/system account);
-// fetch errors fail the sync to keep the previous-good .c1z canonical.
-func (o *userBuilder) fetchWorker(ctx context.Context, userID string) (*client.Worker, error) {
-	resp, _, err := o.client.GetWorkersByUserID(ctx, userID)
+// Fallback for users the /workers pagination missed.
+//
+// Someone who has been rehired may have more than one worker record. We
+// use the most recently updated one.
+func (o *userBuilder) fetchWorker(ctx context.Context, userID string) (*client.Worker, *v2.RateLimitDescription, error) {
+	resp, rl, err := o.client.GetWorkersByUserID(ctx, userID)
 	if err != nil {
-		return nil, fmt.Errorf("baton-rippling: on-demand worker fetch failed for user %s: %w", userID, err)
+		return nil, rl, fmt.Errorf("baton-rippling: on-demand worker fetch failed for user %s: %w", userID, err)
 	}
 	if len(resp.Results) == 0 {
-		return nil, nil
+		return nil, rl, nil
 	}
 	chosen := resp.Results[0]
-	return &chosen, nil
+	for _, w := range resp.Results[1:] {
+		if w.UpdatedAt > chosen.UpdatedAt {
+			chosen = w
+		}
+	}
+	return &chosen, rl, nil
 }
 
 func newUserBuilder(client *client.Client, expandWorkLocations bool, customFieldNames []string) *userBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -389,6 +389,12 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 		var workerPtr *client.Worker
 		if worker, found := workers[user.ID]; found {
 			workerPtr = &worker
+		} else {
+			recovered, err := o.fetchWorker(ctx, user.ID)
+			if err != nil {
+				return nil, &resource.SyncOpResults{Annotations: annos}, err
+			}
+			workerPtr = recovered
 		}
 
 		var workLocationPtr *client.WorkLocation
@@ -474,9 +480,15 @@ func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.
 		return nil, nil, fmt.Errorf("baton-rippling: failed to get worker for user %s from session store: %w", r.Id.Resource, err)
 	}
 	if !found {
-		l := ctxzap.Extract(ctx)
-		l.Debug("no worker found for user, skipping team grants", zap.String("user_id", r.Id.Resource))
-		return nil, nil, nil
+		recovered, err := o.fetchWorker(ctx, r.Id.Resource)
+		if err != nil {
+			return nil, nil, err
+		}
+		if recovered == nil {
+			ctxzap.Extract(ctx).Debug("no worker exists for user, skipping team grants", zap.String("user_id", r.Id.Resource))
+			return nil, nil, nil
+		}
+		worker = *recovered
 	}
 	if worker.Status == "TERMINATED" {
 		l := ctxzap.Extract(ctx)
@@ -499,6 +511,23 @@ func (o *userBuilder) Grants(ctx context.Context, r *v2.Resource, opts resource.
 	}
 
 	return rv, nil, nil
+}
+
+// fetchWorker fetches a worker by user_id via the /workers filter API. Used
+// to recover from /workers cursor-walk misses where a user appears in /users
+// but the bulk pagination did not return their worker. A nil result means
+// Rippling has no worker for this user (legitimate admin/system account);
+// fetch errors fail the sync to keep the previous-good .c1z canonical.
+func (o *userBuilder) fetchWorker(ctx context.Context, userID string) (*client.Worker, error) {
+	resp, _, err := o.client.GetWorkersByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("baton-rippling: on-demand worker fetch failed for user %s: %w", userID, err)
+	}
+	if len(resp.Results) == 0 {
+		return nil, nil
+	}
+	chosen := resp.Results[0]
+	return &chosen, nil
 }
 
 func newUserBuilder(client *client.Client, expandWorkLocations bool, customFieldNames []string) *userBuilder {


### PR DESCRIPTION
## Summary

The `/workers` cursor-walk does not always return a worker for every user that appears in `/users`. When phase 3 looks up a user's worker in the session store and misses, the connector previously emitted the user with `worker == nil` — status fell through to `STATUS_UNSPECIFIED` and `Grants()` returned no team memberships. Downstream automations that key off user status interpret `UNSPECIFIED` as disabled and trigger revocations.

## Changes

- **`pkg/client/endpoints.go`** — new `GetWorkersByUserID(ctx, userID)` issuing `GET /workers?filter=user_id+eq+'<id>'`. Returns a slice (re-hire case where one user has multiple workers).
- **`pkg/connector/users.go`** — on cache miss in `listUserPage` and `Grants()`, call new helper `fetchWorker(ctx, userID)`:
  - Fetch error → propagate up, sync fails, previous-good `.c1z` stays canonical (refuse to degrade).
  - Empty result → treated as legitimate "no worker exists" (admin/system accounts); status falls through to `STATUS_UNSPECIFIED`, `Grants()` returns no team memberships. Same as before for that case.
  - Worker recovered → used for status / grants emission.

## What this does NOT do

- No session writeback. The recovery API call may run twice per missing user within a sync (once for status in `listUserPage`, once for grants in `Grants()`). Accepted tradeoff to keep the change small.
- Re-hire collisions (multiple workers per `user_id`) take `Results[0]` without precedence, matching the existing last-write-wins behavior in `listWorkerPage`. Out of scope.
- No mapping changes for `HIRED` / `INIT` / `ACCEPTED` / `TERMINATED` enum values. Out of scope.

## Test plan

- [ ] `go build ./...` passes.
- [ ] `go test ./...` passes.
- [ ] Sync against a tenant that previously exhibited the missing-worker symptom and confirm status + grants are now stable across syncs.
- [ ] Confirm a transient `/workers` filter API failure fails the sync rather than emitting incomplete data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)