### PR TITLE
Attempt to recover worker location.

### DIFF
--- a/pkg/client/endpoints.go
+++ b/pkg/client/endpoints.go
@@ -95,6 +95,19 @@ func (c *Client) ListWorkLocations(ctx context.Context, nextLink string) (*WorkL
 	return &workLocations, rl, nil
 }
 
+func (c *Client) GetWorkLocationByID(ctx context.Context, locationID string) (*WorkLocation, *v2.RateLimitDescription, error) {
+	u, err := url.JoinPath(c.workLocationsURL(), locationID+"/")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build work location URL for %s: %w", locationID, err)
+	}
+	var workLocation WorkLocation
+	rl, err := c.doGet(ctx, u, "", &workLocation)
+	if err != nil {
+		return nil, rl, fmt.Errorf("failed to fetch work location %s: %w", locationID, err)
+	}
+	return &workLocation, rl, nil
+}
+
 func (c *Client) ListUsers(ctx context.Context, nextLink string) (*UsersResponse, *v2.RateLimitDescription, error) {
 	var usersResponse UsersResponse
 	rl, err := c.doGet(ctx, c.usersURL(), nextLink, &usersResponse)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -400,8 +400,19 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 
 		var workLocationPtr *client.WorkLocation
 		if o.expandWorkLocations && workerPtr != nil && workerPtr.Location != nil && workerPtr.Location.WorkLocationID != "" {
-			if wl, ok := workLocations[workerPtr.Location.WorkLocationID]; ok {
+			locationID := workerPtr.Location.WorkLocationID
+			if wl, ok := workLocations[locationID]; ok {
 				workLocationPtr = &wl
+			} else {
+				recovered, rl, err := o.fetchWorkLocation(ctx, locationID)
+				annos = *annos.WithRateLimiting(rl)
+				if err != nil {
+					return nil, &resource.SyncOpResults{Annotations: annos}, err
+				}
+				if recovered == nil {
+					return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: worker for user %s references work location %s but it was not found", user.ID, locationID)
+				}
+				workLocationPtr = recovered
 			}
 		}
 
@@ -534,6 +545,14 @@ func (o *userBuilder) fetchWorker(ctx context.Context, userID string) (*client.W
 		}
 	}
 	return &chosen, rl, nil
+}
+
+func (o *userBuilder) fetchWorkLocation(ctx context.Context, locationID string) (*client.WorkLocation, *v2.RateLimitDescription, error) {
+	wl, rl, err := o.client.GetWorkLocationByID(ctx, locationID)
+	if err != nil {
+		return nil, rl, fmt.Errorf("baton-rippling: on-demand work location fetch failed for %s: %w", locationID, err)
+	}
+	return wl, rl, nil
 }
 
 func newUserBuilder(client *client.Client, expandWorkLocations bool, customFieldNames []string) *userBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -409,9 +409,6 @@ func (o *userBuilder) listUserPage(ctx context.Context, pageToken string, ss ses
 				if err != nil {
 					return nil, &resource.SyncOpResults{Annotations: annos}, err
 				}
-				if recovered == nil {
-					return nil, &resource.SyncOpResults{Annotations: annos}, fmt.Errorf("baton-rippling: worker for user %s references work location %s but it was not found", user.ID, locationID)
-				}
 				workLocationPtr = recovered
 			}
 		}


### PR DESCRIPTION
Similar to the recover worker status/profile fix. There needs to be a more comprehensive fix. This connector is used for JML and these patches are bandaids.