### PR TITLE
Guard team grant emission behind WillSyncResourceType

### DIFF
--- a/cmd/baton-rippling/main.go
+++ b/cmd/baton-rippling/main.go
@@ -53,12 +53,16 @@ func getConnector(ctx context.Context, config *cfg.Rippling, runTimeOpts cli.Run
 		return nil, err
 	}
 
+	// An empty SyncResourceTypeIDs means no filter, so nothing is skipped.
+	connectorOpts := &cli.ConnectorOpts{SyncResourceTypeIDs: runTimeOpts.SyncResourceTypeIDs}
+	skipTeamResourceType := !connectorOpts.WillSyncResourceType(connector.TeamResourceTypeID)
+
 	cb, err := connector.New(ctx, config.ApiToken, config.BaseUrl, client.ExpandOptions{
 		Department:     config.ExpandDepartment,
 		EmploymentType: config.ExpandEmploymentType,
 		Level:          config.ExpandLevel,
 		CustomFields:   len(config.CustomFields) > 0,
-	}, config.ExpandWorkLocations, config.CustomFields)
+	}, config.ExpandWorkLocations, config.CustomFields, skipTeamResourceType)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -15,12 +15,16 @@ type Connector struct {
 	client              *client.Client
 	expandWorkLocations bool
 	customFieldNames    []string
+	// skipTeamResourceType reports whether team is excluded from the sync
+	// filter. Named for the skip condition so the zero value is safe: main.go
+	// registers a zero-value Connector{} as the capabilities factory.
+	skipTeamResourceType bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client, d.expandWorkLocations, d.customFieldNames),
+		newUserBuilder(d.client, d.expandWorkLocations, d.customFieldNames, d.skipTeamResourceType),
 		newTeamBuilder(d.client),
 	}
 }
@@ -46,14 +50,15 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiToken string, baseURL string, expandOpts client.ExpandOptions, expandWorkLocations bool, customFieldNames []string) (*Connector, error) {
+func New(ctx context.Context, apiToken string, baseURL string, expandOpts client.ExpandOptions, expandWorkLocations bool, customFieldNames []string, skipTeamResourceType bool) (*Connector, error) {
 	c, err := client.New(ctx, apiToken, baseURL, expandOpts)
 	if err != nil {
 		return nil, fmt.Errorf("baton-rippling: failed to create client: %w", err)
 	}
 	return &Connector{
-		client:              c,
-		expandWorkLocations: expandWorkLocations,
-		customFieldNames:    customFieldNames,
+		client:               c,
+		expandWorkLocations:  expandWorkLocations,
+		customFieldNames:     customFieldNames,
+		skipTeamResourceType: skipTeamResourceType,
 	}, nil
 }

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -6,15 +6,19 @@ import (
 )
 
 // The user resource type is for all user objects from the database.
+// newUserBuilder clones this and adds SkipEntitlements, or
+// SkipEntitlementsAndGrants when team isn't synced.
 var userResourceType = &v2.ResourceType{
 	Id:          "user",
 	DisplayName: "User",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
-	Annotations: annotations.New(&v2.SkipEntitlements{}),
 }
 
+// TeamResourceTypeID is referenced when gating cross-type team grants.
+const TeamResourceTypeID = "team"
+
 var teamResourceType = &v2.ResourceType{
-	Id:          "team",
+	Id:          TeamResourceTypeID,
 	DisplayName: "Team",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_GROUP},
 	Annotations: annotations.New(&v2.SkipGrants{}),

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -16,6 +16,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
 
 const workType = "WORK"
@@ -34,12 +35,13 @@ const (
 
 type userBuilder struct {
 	client              *client.Client
+	resourceType        *v2.ResourceType
 	expandWorkLocations bool
 	customFieldNames    []string
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	return userResourceType
+	return o.resourceType
 }
 
 func userResource(user client.User, worker *client.Worker, workLocation *client.WorkLocation, customFieldNames []string) (*v2.Resource, error) {
@@ -552,8 +554,21 @@ func (o *userBuilder) fetchWorkLocation(ctx context.Context, locationID string) 
 	return wl, rl, nil
 }
 
-func newUserBuilder(client *client.Client, expandWorkLocations bool, customFieldNames []string) *userBuilder {
+// newUserBuilder returns the user syncer. Users have no entitlements of their
+// own, and their only grants are cross-type team grants, so when team is
+// excluded from the sync the grants pass is skipped too.
+func newUserBuilder(client *client.Client, expandWorkLocations bool, customFieldNames []string, skipTeamResourceType bool) *userBuilder {
+	rt := proto.Clone(userResourceType).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipTeamResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userBuilder{
+		resourceType:        rt,
 		client:              client,
 		expandWorkLocations: expandWorkLocations,
 		customFieldNames:    customFieldNames,

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasGuardAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type team grants, so when team is
+// excluded the whole grants pass is skipped.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	inScope := newUserBuilder(nil, false, nil, false).ResourceType(context.Background())
+	if !hasGuardAnno(inScope, &v2.SkipEntitlements{}) || hasGuardAnno(inScope, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("team in scope: want SkipEntitlements only, got %v", inScope.Annotations)
+	}
+
+	filtered := newUserBuilder(nil, false, nil, true).ResourceType(context.Background())
+	if !hasGuardAnno(filtered, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("team filtered: want SkipEntitlementsAndGrants, got %v", filtered.Annotations)
+	}
+
+	if hasGuardAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatal("package-level userResourceType was mutated")
+	}
+}
+
+// main.go registers a zero-value Connector{} as the capabilities factory, which
+// bypasses New; it must report the unfiltered capability set.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != userResourceType.Id {
+			continue
+		}
+		if hasGuardAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+}


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

Each target is guarded individually in Grants(); when every target is excluded
the user resource type is annotated SkipEntitlementsAndGrants so the SDK skips
the pass entirely.

Flags are named skip<Type>ResourceType and stored inverted so the zero value
means "sync everything" — main.go registers a zero-value Connector{} as the
capabilities factory, bypassing New.

Build, tests, and golangci-lint (0 issues) pass.
